### PR TITLE
Implement report generation (JSON and HTML formats)

### DIFF
--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::discover::{InstalledPackage, PackageSource};
+use crate::report::terminal::{group_by_project, sort_packages};
+
+/// Escape HTML special characters.
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Generate an HTML report and print it to stdout.
+pub fn print_html(packages: &[InstalledPackage], timestamp: DateTime<Utc>) {
+    let mut sorted = packages.to_vec();
+    sort_packages(&mut sorted);
+
+    let mut by_source: HashMap<&PackageSource, usize> = HashMap::new();
+    for pkg in &sorted {
+        *by_source.entry(&pkg.source).or_default() += 1;
+    }
+    let mut sources: Vec<_> = by_source.iter().collect();
+    sources.sort_by_key(|(s, _)| **s);
+
+    let groups = group_by_project(&sorted);
+    let with_url: Vec<_> = groups.iter().filter(|g| !g.url.is_empty()).collect();
+
+    let mut html = String::new();
+
+    html.push_str("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+    html.push_str("<meta charset=\"utf-8\">\n");
+    html.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    html.push_str("<title>syld report</title>\n");
+    html.push_str("<style>\n");
+    html.push_str(
+        "body { font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }\n",
+    );
+    html.push_str("h1, h2 { margin-top: 2rem; }\n");
+    html.push_str("table { border-collapse: collapse; width: 100%; margin: 1rem 0; }\n");
+    html.push_str(
+        "th, td { text-align: left; padding: 0.5rem 1rem; border-bottom: 1px solid #ddd; }\n",
+    );
+    html.push_str("th { background: #f5f5f5; }\n");
+    html.push_str("tr:hover { background: #fafafa; }\n");
+    html.push_str(".meta { color: #666; font-size: 0.9rem; }\n");
+    html.push_str("</style>\n");
+    html.push_str("</head>\n<body>\n");
+
+    html.push_str("<h1>syld report</h1>\n");
+    html.push_str(&format!(
+        "<p class=\"meta\">Scan date: {}</p>\n",
+        escape_html(&timestamp.format("%Y-%m-%d %H:%M UTC").to_string())
+    ));
+    html.push_str(&format!(
+        "<p class=\"meta\">Total packages: {}</p>\n",
+        sorted.len()
+    ));
+
+    // Source summary
+    html.push_str("<h2>Sources</h2>\n");
+    html.push_str("<table>\n<tr><th>Source</th><th>Packages</th></tr>\n");
+    for (source, count) in &sources {
+        html.push_str(&format!(
+            "<tr><td>{}</td><td>{}</td></tr>\n",
+            escape_html(&source.to_string()),
+            count,
+        ));
+    }
+    html.push_str("</table>\n");
+
+    // Projects
+    if !with_url.is_empty() {
+        html.push_str("<h2>Upstream projects</h2>\n");
+        html.push_str(&format!(
+            "<p class=\"meta\">{} packages grouped into {} projects</p>\n",
+            sorted.len(),
+            with_url.len()
+        ));
+        html.push_str("<table>\n<tr><th>Project</th><th>Packages</th></tr>\n");
+
+        for group in &with_url {
+            let pkg_names: Vec<_> = group
+                .packages
+                .iter()
+                .map(|p| escape_html(&p.name))
+                .collect();
+            html.push_str(&format!(
+                "<tr><td>{}</td><td>{}</td></tr>\n",
+                escape_html(&group.url),
+                pkg_names.join(", "),
+            ));
+        }
+
+        html.push_str("</table>\n");
+    }
+
+    html.push_str("</body>\n</html>\n");
+
+    print!("{html}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discover::PackageSource;
+
+    fn sample_packages() -> Vec<InstalledPackage> {
+        vec![
+            InstalledPackage {
+                name: "firefox".to_string(),
+                version: "128.0".to_string(),
+                description: Some("Web browser".to_string()),
+                url: Some("https://www.mozilla.org/firefox/".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["MPL-2.0".to_string()],
+            },
+            InstalledPackage {
+                name: "linux".to_string(),
+                version: "6.9.7".to_string(),
+                description: None,
+                url: Some("https://kernel.org".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["GPL-2.0".to_string()],
+            },
+        ]
+    }
+
+    #[test]
+    fn html_escapes_special_chars() {
+        assert_eq!(escape_html("<script>"), "&lt;script&gt;");
+        assert_eq!(escape_html("a&b"), "a&amp;b");
+        assert_eq!(escape_html("\"quoted\""), "&quot;quoted&quot;");
+    }
+
+    #[test]
+    fn html_contains_expected_structure() {
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        // Capture stdout by building the same HTML string
+        let mut sorted = packages.to_vec();
+        sort_packages(&mut sorted);
+
+        let groups = group_by_project(&sorted);
+        let with_url: Vec<_> = groups.iter().filter(|g| !g.url.is_empty()).collect();
+
+        // Just verify the building blocks work
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(with_url.len(), 2);
+        assert!(
+            timestamp
+                .format("%Y-%m-%d %H:%M UTC")
+                .to_string()
+                .contains("2025")
+        );
+    }
+
+    #[test]
+    fn html_empty_packages() {
+        let packages: Vec<InstalledPackage> = vec![];
+        let sorted = packages.clone();
+        let groups = group_by_project(&sorted);
+        let with_url: Vec<_> = groups.iter().filter(|g| !g.url.is_empty()).collect();
+        assert!(with_url.is_empty());
+    }
+}

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::discover::InstalledPackage;
+
+/// A JSON-serializable report of a scan.
+#[derive(Serialize)]
+pub struct JsonReport {
+    pub scan_timestamp: DateTime<Utc>,
+    pub total_packages: usize,
+    pub packages: Vec<InstalledPackage>,
+}
+
+/// Generate a JSON report and print it to stdout.
+pub fn print_json(packages: &[InstalledPackage], timestamp: DateTime<Utc>) -> Result<()> {
+    let report = JsonReport {
+        scan_timestamp: timestamp,
+        total_packages: packages.len(),
+        packages: packages.to_vec(),
+    };
+
+    let json = serde_json::to_string_pretty(&report)?;
+    println!("{json}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discover::PackageSource;
+
+    fn sample_packages() -> Vec<InstalledPackage> {
+        vec![
+            InstalledPackage {
+                name: "firefox".to_string(),
+                version: "128.0".to_string(),
+                description: Some("Web browser".to_string()),
+                url: Some("https://www.mozilla.org/firefox/".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["MPL-2.0".to_string()],
+            },
+            InstalledPackage {
+                name: "linux".to_string(),
+                version: "6.9.7".to_string(),
+                description: None,
+                url: Some("https://kernel.org".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["GPL-2.0".to_string()],
+            },
+        ]
+    }
+
+    #[test]
+    fn json_report_structure() {
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let report = JsonReport {
+            scan_timestamp: timestamp,
+            total_packages: packages.len(),
+            packages: packages.clone(),
+        };
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["total_packages"], 2);
+        assert_eq!(parsed["packages"][0]["name"], "firefox");
+        assert_eq!(parsed["packages"][0]["version"], "128.0");
+        assert_eq!(parsed["packages"][0]["source"], "Pacman");
+        assert_eq!(parsed["packages"][0]["licenses"][0], "MPL-2.0");
+        assert_eq!(parsed["packages"][1]["name"], "linux");
+        assert!(parsed["scan_timestamp"].as_str().unwrap().contains("2025"));
+    }
+
+    #[test]
+    fn json_report_empty_packages() {
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let report = JsonReport {
+            scan_timestamp: timestamp,
+            total_packages: 0,
+            packages: vec![],
+        };
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["total_packages"], 0);
+        assert!(parsed["packages"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn json_report_optional_fields() {
+        let packages = vec![InstalledPackage {
+            name: "orphan".to_string(),
+            version: "1.0".to_string(),
+            description: None,
+            url: None,
+            source: PackageSource::Pacman,
+            licenses: vec![],
+        }];
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let report = JsonReport {
+            scan_timestamp: timestamp,
+            total_packages: 1,
+            packages,
+        };
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert!(parsed["packages"][0]["description"].is_null());
+        assert!(parsed["packages"][0]["url"].is_null());
+        assert!(
+            parsed["packages"][0]["licenses"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,4 +2,6 @@
 
 //! Report generation in multiple output formats.
 
+pub mod html;
+pub mod json;
 pub mod terminal;

--- a/tests/report_cli.rs
+++ b/tests/report_cli.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+use syld::discover::{InstalledPackage, PackageSource};
+use syld::storage::Storage;
+
+fn syld_with_db(config_home: &Path, data_home: &Path) -> Command {
+    let mut cmd: Command = cargo_bin_cmd!("syld").into();
+    cmd.env("XDG_CONFIG_HOME", config_home);
+    cmd.env("XDG_DATA_HOME", data_home);
+    cmd
+}
+
+fn seed_scan(data_home: &Path) {
+    let db_dir = data_home.join("syld");
+    std::fs::create_dir_all(&db_dir).unwrap();
+    let storage = Storage::open_path(&db_dir.join("syld.db")).unwrap();
+
+    let packages = vec![
+        InstalledPackage {
+            name: "firefox".to_string(),
+            version: "128.0".to_string(),
+            description: Some("Web browser".to_string()),
+            url: Some("https://www.mozilla.org/firefox/".to_string()),
+            source: PackageSource::Pacman,
+            licenses: vec!["MPL-2.0".to_string()],
+        },
+        InstalledPackage {
+            name: "linux".to_string(),
+            version: "6.9.7".to_string(),
+            description: None,
+            url: Some("https://kernel.org".to_string()),
+            source: PackageSource::Pacman,
+            licenses: vec!["GPL-2.0".to_string()],
+        },
+        InstalledPackage {
+            name: "orphan".to_string(),
+            version: "1.0".to_string(),
+            description: None,
+            url: None,
+            source: PackageSource::Pacman,
+            licenses: vec![],
+        },
+    ];
+    storage.save_scan(&packages).unwrap();
+}
+
+#[test]
+fn report_no_scan_shows_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["report"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No scan data found"));
+}
+
+#[test]
+fn report_terminal_shows_table() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["report", "--format", "terminal"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pacman"))
+        .stdout(predicate::str::contains("firefox"));
+}
+
+#[test]
+fn report_json_is_valid() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+
+    let output = syld_with_db(tmp.path(), data.path())
+        .args(["report", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("not valid JSON");
+    assert_eq!(parsed["total_packages"], 3);
+    assert_eq!(parsed["packages"][0]["name"], "firefox");
+}
+
+#[test]
+fn report_html_contains_structure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["report", "--format", "html"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<!DOCTYPE html>"))
+        .stdout(predicate::str::contains("<title>syld report</title>"))
+        .stdout(predicate::str::contains("firefox"))
+        .stdout(predicate::str::contains("kernel.org"));
+}


### PR DESCRIPTION
## Summary

- Wires up `syld report` to load the latest scan from SQLite storage
- Implements `--format terminal` (reuses existing terminal formatting, shows all projects)
- Implements `--format json` with structured output (scan timestamp, total count, full package list)
- Implements `--format html` with a clean, self-contained HTML report (source summary + project groupings)
- Shows a helpful message when no scan data exists yet

## Test plan

- [x] All 66 existing + new tests pass (`cargo test`)
- [x] Pre-commit hooks pass (clippy + fmt)
- [x] Integration tests cover: no-scan message, terminal output, JSON validity, HTML structure
- [x] Unit tests cover: JSON serialization, HTML escaping, empty/optional field handling

Closes #12