### PR TITLE
Group related upstream projects by common URL ancestor

### DIFF
--- a/schemas/report.v1.json
+++ b/schemas/report.v1.json
@@ -4,7 +4,7 @@
   "title": "syld JSON Report",
   "description": "Schema for the JSON report produced by `syld report --format json`, containing a timestamped inventory of installed packages and their license information.",
   "type": "object",
-  "required": ["scan_timestamp", "total_packages", "total_projects", "packages_without_url", "packages"],
+  "required": ["scan_timestamp", "total_packages", "total_projects", "packages_without_url", "projects", "packages"],
   "additionalProperties": false,
   "properties": {
     "scan_timestamp": {
@@ -20,12 +20,19 @@
     "total_projects": {
       "type": "integer",
       "minimum": 0,
-      "description": "Number of distinct upstream projects identified (packages with a project URL)."
+      "description": "Number of distinct upstream project groups identified (packages with a project URL)."
     },
     "packages_without_url": {
       "type": "integer",
       "minimum": 0,
       "description": "Number of packages that have no upstream project URL."
+    },
+    "projects": {
+      "type": "array",
+      "description": "Upstream project groups, with related projects merged under common URL ancestors.",
+      "items": {
+        "$ref": "#/$defs/project"
+      }
     },
     "packages": {
       "type": "array",
@@ -36,6 +43,33 @@
     }
   },
   "$defs": {
+    "project": {
+      "type": "object",
+      "title": "ProjectGroup",
+      "description": "A group of related upstream projects, possibly merged under a common URL ancestor.",
+      "required": ["url", "project_urls", "package_names"],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The grouping URL — either an exact project URL or a common ancestor prefix."
+        },
+        "project_urls": {
+          "type": "array",
+          "description": "Individual project URLs within an ancestor group. Empty for single-project groups.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "package_names": {
+          "type": "array",
+          "description": "Names of all packages belonging to this project group.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "package": {
       "type": "object",
       "title": "InstalledPackage",

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -120,6 +120,8 @@ pub fn print_html(packages: &[InstalledPackage], timestamp: DateTime<Utc>) {
                 .collect();
             let url_cell = if group.url.is_empty() {
                 "<em>no project URL</em>".to_string()
+            } else if !group.project_urls.is_empty() {
+                format!("{}/*", escape_html(&group.url))
             } else {
                 escape_html(&group.url)
             };


### PR DESCRIPTION
## Summary

Closes #36

- Adds `compute_ancestor()` to detect shared URL parent paths (e.g. `github.com/systemd` for `github.com/systemd/systemd` and `github.com/systemd/resolved`)
- Merges exact-URL groups into a single ancestor group when 2+ sibling projects share the same parent, displayed with a `/*` suffix
- Updates all three output formats (terminal, HTML, JSON) to show ancestor groups
- Adds a `projects` array to the JSON report with grouped project data
- Updates the JSON schema (`report.v1.json`) with the new `project` definition

## Test plan

- [x] 10 new unit tests for `compute_ancestor` and ancestor grouping logic
- [x] 4 new integration tests verifying ancestor groups in terminal, HTML, JSON output and schema validation
- [x] All 192 existing + new tests pass
- [x] No new clippy warnings