### PR TITLE
Expand data model for budget, enrichment, and contributions

### DIFF
--- a/schemas/report.v1.json
+++ b/schemas/report.v1.json
@@ -67,6 +67,25 @@
           "items": {
             "type": "string"
           }
+        },
+        "is_open_source": {
+          "type": ["boolean", "null"],
+          "description": "Whether the project is open source (resolved from license analysis). Null if unknown."
+        },
+        "documentation_url": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL to the project's documentation, or null if unavailable."
+        },
+        "good_first_issues_url": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL to beginner-friendly issues for this project, or null if unavailable."
+        },
+        "stars": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Star/favorite count (e.g. GitHub stars), or null if unavailable."
         }
       }
     },
@@ -96,7 +115,7 @@
         },
         "source": {
           "type": "string",
-          "enum": ["Pacman", "Apt", "Dnf", "Flatpak", "Snap", "Nix", "Mise"],
+          "enum": ["Pacman", "Apt", "Dnf", "Flatpak", "Snap", "Nix", "Mise", "Brew", "Docker", "Podman"],
           "description": "The package manager source that provides this package."
         },
         "licenses": {

--- a/src/budget/mod.rs
+++ b/src/budget/mod.rs
@@ -30,4 +30,32 @@ pub struct Allocation {
 
     /// Suggested funding channel
     pub via: Option<String>,
+
+    /// Reason for including this project (e.g. "top dependency", "most used")
+    pub reason: Option<String>,
+}
+
+/// A record of a completed donation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DonationRecord {
+    /// Database row ID
+    pub id: i64,
+
+    /// URL of the project that received the donation
+    pub project_url: String,
+
+    /// Amount donated
+    pub amount: f64,
+
+    /// Currency code (e.g. "USD", "EUR")
+    pub currency: String,
+
+    /// When the donation was made
+    pub donated_at: chrono::DateTime<chrono::Utc>,
+
+    /// Funding channel used
+    pub via: Option<String>,
+
+    /// Free-form notes
+    pub notes: Option<String>,
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -25,6 +25,22 @@ pub struct UpstreamProject {
 
     /// Contributing guide URL (populated by enrichment)
     pub contributing_url: Option<String>,
+
+    /// Whether the project is open source (resolved from license analysis)
+    #[serde(default)]
+    pub is_open_source: Option<bool>,
+
+    /// Project documentation URL
+    #[serde(default)]
+    pub documentation_url: Option<String>,
+
+    /// Link to beginner-friendly issues
+    #[serde(default)]
+    pub good_first_issues_url: Option<String>,
+
+    /// Star/favorite count (e.g. GitHub stars)
+    #[serde(default)]
+    pub stars: Option<u64>,
 }
 
 /// A way to financially support a project.


### PR DESCRIPTION
## Summary

- Adds `is_open_source`, `documentation_url`, `good_first_issues_url`, `stars` fields to `UpstreamProject` (with `#[serde(default)]` for backward-compatible deserialization of existing enrichment cache)
- Adds `reason` field to `Allocation` and new `DonationRecord` struct in `budget` module
- Adds `projects` and `donation_history` SQLite tables with full CRUD methods (`save_project`, `get_project`, `all_projects`, `save_donation`, `donations_since`)
- Fixes JSON schema `source` enum to include `Brew`, `Docker`, `Podman` (gap from #32–#34)
- Adds new optional enrichment fields to the report JSON schema project definition

Prepares the data layer for #13 (budget management), #15 (enrichment/funding links), and #26 (non-monetary contributions) without changing any existing behavior.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 203 existing + new tests pass
- [x] `cargo clippy` — no warnings
- [x] New tests cover: project CRUD, donation history, backward-compatible deserialization of old cache entries missing new fields