### PR TITLE
Surface contribution actions in report output

### DIFF
--- a/schemas/report.v1.json
+++ b/schemas/report.v1.json
@@ -4,7 +4,7 @@
   "title": "syld JSON Report",
   "description": "Schema for the JSON report produced by `syld report --format json`, containing a timestamped inventory of installed packages and their license information.",
   "type": "object",
-  "required": ["scan_timestamp", "total_packages", "total_projects", "packages_without_url", "projects", "packages"],
+  "required": ["scan_timestamp", "total_packages", "total_projects", "packages_without_url", "projects_with_contributions", "total_contribution_opportunities", "projects", "packages"],
   "additionalProperties": false,
   "properties": {
     "scan_timestamp": {
@@ -26,6 +26,16 @@
       "type": "integer",
       "minimum": 0,
       "description": "Number of packages that have no upstream project URL."
+    },
+    "projects_with_contributions": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of projects that have at least one contribution opportunity."
+    },
+    "total_contribution_opportunities": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total number of contribution opportunities across all projects."
     },
     "projects": {
       "type": "array",
@@ -86,6 +96,40 @@
           "type": ["integer", "null"],
           "minimum": 0,
           "description": "Star/favorite count (e.g. GitHub stars), or null if unavailable."
+        },
+        "contributions": {
+          "type": "array",
+          "description": "Contribution opportunities for this project. Omitted when empty.",
+          "items": {
+            "$ref": "#/$defs/contribution_opportunity"
+          }
+        }
+      }
+    },
+    "contribution_opportunity": {
+      "type": "object",
+      "title": "ContributionOpportunity",
+      "description": "A concrete opportunity to contribute to an upstream project.",
+      "required": ["kind", "title", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["Star", "GoodFirstIssue", "BugReport", "Translation", "Documentation", "SpreadTheWord"],
+          "description": "The type of contribution."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title for this opportunity."
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Optional longer description or context."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL the user can visit to act on this opportunity."
         }
       }
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 
 use syld::config::Config;
 use syld::discover;
-use syld::report::{html, json, terminal};
+use syld::report::{ContributionMap, html, json, terminal};
 use syld::storage::Storage;
 
 #[derive(Parser)]
@@ -153,7 +153,12 @@ fn cmd_scan(config: &Config, limit: usize) -> Result<()> {
     }
 
     terminal::sort_packages(&mut all_packages);
-    terminal::print_summary(&all_packages, limit, chrono::Utc::now());
+    terminal::print_summary(
+        &all_packages,
+        limit,
+        chrono::Utc::now(),
+        &ContributionMap::new(),
+    );
 
     Ok(())
 }
@@ -172,17 +177,19 @@ fn cmd_report(_config: &Config, format: &ReportFormat) -> Result<()> {
         }
     };
 
+    let contributions = ContributionMap::new();
+
     match format {
         ReportFormat::Terminal => {
             let mut packages = scan.packages;
             terminal::sort_packages(&mut packages);
-            terminal::print_summary(&packages, 0, scan.timestamp);
+            terminal::print_summary(&packages, 0, scan.timestamp, &contributions);
         }
         ReportFormat::Json => {
-            json::print_json(&scan.packages, scan.timestamp)?;
+            json::print_json(&scan.packages, scan.timestamp, &contributions)?;
         }
         ReportFormat::Html => {
-            html::print_html(&scan.packages, scan.timestamp);
+            html::print_html(&scan.packages, scan.timestamp, &contributions);
         }
     }
 

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -4,8 +4,10 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
+use crate::contribute::ContributionOpportunity;
 use crate::discover::InstalledPackage;
 use crate::report::terminal::group_by_project;
+use crate::report::{ContributionMap, lookup_contributions};
 
 /// A grouped upstream project for the JSON report.
 #[derive(Serialize)]
@@ -17,6 +19,10 @@ pub struct JsonProject {
     pub project_urls: Vec<String>,
     /// Names of all packages that belong to this group.
     pub package_names: Vec<String>,
+    /// Contribution opportunities for this project.
+    /// Empty when no contribution data is available.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contributions: Vec<ContributionOpportunity>,
 }
 
 /// A JSON-serializable report of a scan.
@@ -26,12 +32,18 @@ pub struct JsonReport {
     pub total_packages: usize,
     pub total_projects: usize,
     pub packages_without_url: usize,
+    pub projects_with_contributions: usize,
+    pub total_contribution_opportunities: usize,
     pub projects: Vec<JsonProject>,
     pub packages: Vec<InstalledPackage>,
 }
 
 /// Generate a JSON report and print it to stdout.
-pub fn print_json(packages: &[InstalledPackage], timestamp: DateTime<Utc>) -> Result<()> {
+pub fn print_json(
+    packages: &[InstalledPackage],
+    timestamp: DateTime<Utc>,
+    contributions: &ContributionMap,
+) -> Result<()> {
     let groups = group_by_project(packages);
     let total_projects = groups.iter().filter(|g| !g.url.is_empty()).count();
     let packages_without_url = packages.iter().filter(|p| p.url.is_none()).count();
@@ -43,19 +55,31 @@ pub fn print_json(packages: &[InstalledPackage], timestamp: DateTime<Utc>) -> Re
             let mut package_names: Vec<String> =
                 g.packages.iter().map(|p| p.name.clone()).collect();
             package_names.sort();
+            let project_contributions =
+                lookup_contributions(&g.url, &g.project_urls, contributions);
             JsonProject {
                 url: g.url.clone(),
                 project_urls: g.project_urls.clone(),
                 package_names,
+                contributions: project_contributions,
             }
         })
         .collect();
+
+    let projects_with_contributions = projects
+        .iter()
+        .filter(|p| !p.contributions.is_empty())
+        .count();
+    let total_contribution_opportunities: usize =
+        projects.iter().map(|p| p.contributions.len()).sum();
 
     let report = JsonReport {
         scan_timestamp: timestamp,
         total_packages: packages.len(),
         total_projects,
         packages_without_url,
+        projects_with_contributions,
+        total_contribution_opportunities,
         projects,
         packages: packages.to_vec(),
     };
@@ -101,16 +125,20 @@ mod tests {
             total_packages: packages.len(),
             total_projects: 2,
             packages_without_url: 0,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![
                 JsonProject {
                     url: "kernel.org".to_string(),
                     project_urls: vec![],
                     package_names: vec!["linux".to_string()],
+                    contributions: vec![],
                 },
                 JsonProject {
                     url: "mozilla.org/firefox".to_string(),
                     project_urls: vec![],
                     package_names: vec!["firefox".to_string()],
+                    contributions: vec![],
                 },
             ],
             packages: packages.clone(),
@@ -140,6 +168,8 @@ mod tests {
             total_packages: 0,
             total_projects: 0,
             packages_without_url: 0,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![],
             packages: vec![],
         };
@@ -171,6 +201,8 @@ mod tests {
             total_packages: 1,
             total_projects: 0,
             packages_without_url: 1,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![],
             packages,
         };
@@ -203,16 +235,20 @@ mod tests {
             total_packages: packages.len(),
             total_projects: 2,
             packages_without_url: 0,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![
                 JsonProject {
                     url: "kernel.org".to_string(),
                     project_urls: vec![],
                     package_names: vec!["linux".to_string()],
+                    contributions: vec![],
                 },
                 JsonProject {
                     url: "mozilla.org/firefox".to_string(),
                     project_urls: vec![],
                     package_names: vec!["firefox".to_string()],
+                    contributions: vec![],
                 },
             ],
             packages,
@@ -235,6 +271,8 @@ mod tests {
             total_packages: 0,
             total_projects: 0,
             packages_without_url: 0,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![],
             packages: vec![],
         };
@@ -264,6 +302,8 @@ mod tests {
             total_packages: packages.len(),
             total_projects: 0,
             packages_without_url: 1,
+            projects_with_contributions: 0,
+            total_contribution_opportunities: 0,
             projects: vec![],
             packages,
         };
@@ -274,5 +314,136 @@ mod tests {
 
         jsonschema::validate(&schema, &instance)
             .expect("Report with null optional fields should validate against the schema");
+    }
+
+    #[test]
+    fn json_report_with_contributions() {
+        use crate::contribute::{ContributionKind, ContributionOpportunity};
+
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let report = JsonReport {
+            scan_timestamp: timestamp,
+            total_packages: packages.len(),
+            total_projects: 2,
+            packages_without_url: 0,
+            projects_with_contributions: 1,
+            total_contribution_opportunities: 2,
+            projects: vec![
+                JsonProject {
+                    url: "kernel.org".to_string(),
+                    project_urls: vec![],
+                    package_names: vec!["linux".to_string()],
+                    contributions: vec![
+                        ContributionOpportunity {
+                            kind: ContributionKind::GoodFirstIssue,
+                            title: "Fix typo in README".to_string(),
+                            description: Some("Simple fix".to_string()),
+                            url: "https://github.com/torvalds/linux/issues/1".to_string(),
+                        },
+                        ContributionOpportunity {
+                            kind: ContributionKind::Documentation,
+                            title: "Improve docs".to_string(),
+                            description: None,
+                            url: "https://github.com/torvalds/linux/issues/2".to_string(),
+                        },
+                    ],
+                },
+                JsonProject {
+                    url: "mozilla.org/firefox".to_string(),
+                    project_urls: vec![],
+                    package_names: vec!["firefox".to_string()],
+                    contributions: vec![],
+                },
+            ],
+            packages: packages.clone(),
+        };
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["projects_with_contributions"], 1);
+        assert_eq!(parsed["total_contribution_opportunities"], 2);
+
+        // Project with contributions includes them
+        let kernel = &parsed["projects"][0];
+        assert_eq!(kernel["contributions"].as_array().unwrap().len(), 2);
+        assert_eq!(kernel["contributions"][0]["kind"], "GoodFirstIssue");
+        assert_eq!(kernel["contributions"][0]["title"], "Fix typo in README");
+        assert_eq!(kernel["contributions"][0]["description"], "Simple fix");
+
+        // Project without contributions omits the field (skip_serializing_if)
+        let firefox = &parsed["projects"][1];
+        assert!(firefox.get("contributions").is_none());
+    }
+
+    #[test]
+    fn json_report_with_contributions_validates_against_schema() {
+        use crate::contribute::{ContributionKind, ContributionOpportunity};
+
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let report = JsonReport {
+            scan_timestamp: timestamp,
+            total_packages: packages.len(),
+            total_projects: 2,
+            packages_without_url: 0,
+            projects_with_contributions: 1,
+            total_contribution_opportunities: 1,
+            projects: vec![JsonProject {
+                url: "kernel.org".to_string(),
+                project_urls: vec![],
+                package_names: vec!["linux".to_string()],
+                contributions: vec![ContributionOpportunity {
+                    kind: ContributionKind::GoodFirstIssue,
+                    title: "Fix bug".to_string(),
+                    description: None,
+                    url: "https://github.com/torvalds/linux/issues/1".to_string(),
+                }],
+            }],
+            packages,
+        };
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let instance: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let schema = load_schema();
+
+        jsonschema::validate(&schema, &instance)
+            .expect("Report with contributions should validate against the schema");
+    }
+
+    #[test]
+    fn print_json_with_contributions() {
+        use crate::contribute::{ContributionKind, ContributionOpportunity};
+
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let mut contributions = ContributionMap::new();
+        contributions.insert(
+            "kernel.org".to_string(),
+            vec![ContributionOpportunity {
+                kind: ContributionKind::GoodFirstIssue,
+                title: "Fix bug".to_string(),
+                description: None,
+                url: "https://github.com/torvalds/linux/issues/1".to_string(),
+            }],
+        );
+
+        // Just verify it doesn't panic — output goes to stdout
+        let result = print_json(&packages, timestamp, &contributions);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn print_json_empty_contributions() {
+        let packages = sample_packages();
+        let timestamp = "2025-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap();
+        let contributions = ContributionMap::new();
+
+        let result = print_json(&packages, timestamp, &contributions);
+        assert!(result.is_ok());
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,6 +2,116 @@
 
 //! Report generation in multiple output formats.
 
+use std::collections::HashMap;
+
+use crate::contribute::ContributionOpportunity;
+
 pub mod html;
 pub mod json;
 pub mod terminal;
+
+/// Contribution opportunities keyed by normalized project URL.
+///
+/// Report functions accept this as an optional parameter so they can display
+/// a "Ways to Help" section alongside the existing package/project tables.
+pub type ContributionMap = HashMap<String, Vec<ContributionOpportunity>>;
+
+/// Look up contributions for a project group, checking both the group URL and
+/// any individual project URLs within an ancestor group.
+pub fn lookup_contributions(
+    group_url: &str,
+    project_urls: &[String],
+    contributions: &ContributionMap,
+) -> Vec<ContributionOpportunity> {
+    let mut result = Vec::new();
+
+    if let Some(opps) = contributions.get(group_url) {
+        result.extend(opps.iter().cloned());
+    }
+
+    for url in project_urls {
+        if let Some(opps) = contributions.get(url.as_str()) {
+            result.extend(opps.iter().cloned());
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contribute::ContributionKind;
+
+    fn make_opp(kind: ContributionKind, title: &str) -> ContributionOpportunity {
+        ContributionOpportunity {
+            kind,
+            title: title.to_string(),
+            description: None,
+            url: "https://example.com".to_string(),
+        }
+    }
+
+    #[test]
+    fn lookup_by_group_url() {
+        let mut map = ContributionMap::new();
+        map.insert(
+            "github.com/foo".to_string(),
+            vec![make_opp(ContributionKind::Star, "Star it")],
+        );
+
+        let result = lookup_contributions("github.com/foo", &[], &map);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].title, "Star it");
+    }
+
+    #[test]
+    fn lookup_by_project_urls() {
+        let mut map = ContributionMap::new();
+        map.insert(
+            "github.com/org/repo-a".to_string(),
+            vec![make_opp(ContributionKind::GoodFirstIssue, "Fix bug")],
+        );
+
+        let project_urls = vec!["github.com/org/repo-a".to_string()];
+        let result = lookup_contributions("github.com/org", &project_urls, &map);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].title, "Fix bug");
+    }
+
+    #[test]
+    fn lookup_merges_group_and_project_urls() {
+        let mut map = ContributionMap::new();
+        map.insert(
+            "github.com/org".to_string(),
+            vec![make_opp(ContributionKind::Star, "Star org")],
+        );
+        map.insert(
+            "github.com/org/repo-a".to_string(),
+            vec![make_opp(ContributionKind::GoodFirstIssue, "Fix bug")],
+        );
+
+        let project_urls = vec!["github.com/org/repo-a".to_string()];
+        let result = lookup_contributions("github.com/org", &project_urls, &map);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn lookup_empty_map_returns_empty() {
+        let map = ContributionMap::new();
+        let result = lookup_contributions("github.com/foo", &[], &map);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn lookup_no_match_returns_empty() {
+        let mut map = ContributionMap::new();
+        map.insert(
+            "github.com/other".to_string(),
+            vec![make_opp(ContributionKind::Star, "Star it")],
+        );
+
+        let result = lookup_contributions("github.com/foo", &[], &map);
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #42

- Added `ContributionMap` type and `lookup_contributions` helper in `report::mod` for shared contribution data lookup across all report formats
- Added `contributions` field to `JsonProject` (skipped when empty) and contribution summary stats (`projects_with_contributions`, `total_contribution_opportunities`) to `JsonReport`
- Added "Ways to Help" section to terminal report with a table of contribution opportunities per project
- Added "Ways to Help" section to HTML report with linked opportunity titles
- Updated JSON schema with `contribution_opportunity` definition and new summary fields
- All three formats gracefully handle empty contribution data (no section shown)

## Test plan

- [x] All 212+ existing tests pass
- [x] 9 new tests added: 5 for `lookup_contributions`, 4 for JSON report with contributions (structure, schema validation, print_json with/without data)
- [x] Clippy clean, cargo fmt clean
- [x] JSON schema validation passes for reports with and without contributions