### PR TITLE
Auto-scan when report is invoked with no prior scan

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use syld::config::Config;
-use syld::discover;
+use syld::discover::{self, InstalledPackage};
 use syld::enrich::EnrichmentMap;
 use syld::report::{ContributionMap, html, json, terminal};
 use syld::storage::Storage;
@@ -147,12 +147,12 @@ fn main() -> Result<()> {
     }
 }
 
-fn cmd_scan(config: &Config, limit: usize) -> Result<()> {
+fn run_scan(config: &Config) -> Result<Vec<InstalledPackage>> {
     let discoverers = discover::active_discoverers(config);
 
     if discoverers.is_empty() {
         eprintln!("No supported package managers detected on this system.");
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let mut all_packages = Vec::new();
@@ -178,6 +178,12 @@ fn cmd_scan(config: &Config, limit: usize) -> Result<()> {
         },
         Err(e) => eprintln!("Warning: failed to open database: {e}"),
     }
+
+    Ok(all_packages)
+}
+
+fn cmd_scan(config: &Config, limit: usize) -> Result<()> {
+    let mut all_packages = run_scan(config)?;
 
     terminal::sort_packages(&mut all_packages);
     terminal::print_summary(
@@ -206,8 +212,18 @@ fn cmd_report(
     let scan = match scan {
         Some(s) => s,
         None => {
-            eprintln!("No scan data found. Run `syld scan` first.");
-            return Ok(());
+            eprintln!("No previous scan found. Running scan first\u{2026}");
+            run_scan(config)?;
+            let fresh = storage
+                .latest_scan()
+                .context("Failed to read scan after auto-scan")?;
+            match fresh {
+                Some(s) => s,
+                None => {
+                    eprintln!("Scan completed but no data was saved.");
+                    return Ok(());
+                }
+            }
         }
     };
 

--- a/tests/report_cli.rs
+++ b/tests/report_cli.rs
@@ -99,14 +99,16 @@ fn single_source_packages() -> Vec<InstalledPackage> {
 }
 
 #[test]
-fn report_no_scan_shows_message() {
+fn report_no_scan_runs_auto_scan() {
     let tmp = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();
     syld_with_db(tmp.path(), data.path())
         .args(["report"])
         .assert()
         .success()
-        .stderr(predicate::str::contains("No scan data found"));
+        .stderr(predicate::str::contains(
+            "No previous scan found. Running scan first",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Extracts core scanning logic from `cmd_scan` into a reusable `run_scan()` helper
- When `syld report` finds no existing scan data, it now automatically runs a scan instead of printing an error and exiting
- Updates the existing test to verify the new auto-scan behavior

Closes #53

## Test plan

- [x] All 269 existing tests pass
- [x] `report_no_scan_runs_auto_scan` test verifies the new behavior
- [x] Manual: run `syld report` with an empty database — should see "No previous scan found. Running scan first…" followed by the report