### PR TITLE
Implement budget management (set/show/plan)

### DIFF
--- a/src/budget/mod.rs
+++ b/src/budget/mod.rs
@@ -8,7 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::project::UpstreamProject;
+use crate::config::{BudgetConfig, Cadence};
+use crate::project::{FundingChannel, UpstreamProject};
 
 /// A complete donation plan for a budget period.
 #[derive(Debug, Serialize, Deserialize)]
@@ -58,4 +59,273 @@ pub struct DonationRecord {
 
     /// Free-form notes
     pub notes: Option<String>,
+}
+
+/// How to distribute the budget across fundable groups.
+#[derive(Debug, Clone, Copy)]
+pub enum AllocationStrategy {
+    /// Divide the budget equally among all groups.
+    Equal,
+    /// Weight each group by its total star count (minimum weight 1).
+    Weighted,
+}
+
+/// A group of related projects (same org/ancestor) that can receive funding.
+pub struct FundableGroup {
+    /// Org/ancestor URL or project name used as the display label.
+    pub label: String,
+    /// Constituent projects in this group.
+    pub projects: Vec<UpstreamProject>,
+    /// Deduplicated funding channels across the group.
+    pub funding: Vec<FundingChannel>,
+    /// Sum of stars across projects in the group.
+    pub total_stars: u64,
+}
+
+/// Generate a donation plan from a budget, a set of fundable groups, and a strategy.
+pub fn generate_plan(
+    budget: &BudgetConfig,
+    groups: Vec<FundableGroup>,
+    strategy: AllocationStrategy,
+) -> DonationPlan {
+    let amount = budget.amount.unwrap_or(0.0);
+    let every_n_months: u32 = match budget.cadence {
+        Cadence::Monthly => 1,
+        Cadence::Yearly => 12,
+    };
+
+    if groups.is_empty() || amount <= 0.0 {
+        return DonationPlan {
+            allocations: vec![],
+        };
+    }
+
+    let allocations = match strategy {
+        AllocationStrategy::Equal => {
+            let per_group = amount / groups.len() as f64;
+            groups
+                .into_iter()
+                .map(|g| make_allocation(g, per_group, every_n_months))
+                .collect()
+        }
+        AllocationStrategy::Weighted => {
+            let weights: Vec<u64> = groups.iter().map(|g| g.total_stars.max(1)).collect();
+            let total_weight: u64 = weights.iter().sum();
+            groups
+                .into_iter()
+                .zip(weights)
+                .map(|(g, w)| {
+                    let share = amount * (w as f64 / total_weight as f64);
+                    make_allocation(g, share, every_n_months)
+                })
+                .collect()
+        }
+    };
+
+    DonationPlan { allocations }
+}
+
+fn make_allocation(group: FundableGroup, amount: f64, every_n_months: u32) -> Allocation {
+    let via = group.funding.first().map(|f| f.url.clone());
+    let reason = if group.projects.len() == 1 {
+        Some("1 installed package".to_string())
+    } else {
+        Some(format!("{} installed packages", group.projects.len()))
+    };
+
+    // Use the group label as the project name; pick the first project's repo_url
+    let representative = group
+        .projects
+        .first()
+        .cloned()
+        .unwrap_or_else(|| UpstreamProject {
+            name: group.label.clone(),
+            repo_url: None,
+            homepage: None,
+            licenses: vec![],
+            funding: group.funding.clone(),
+            bug_tracker: None,
+            contributing_url: None,
+            is_open_source: None,
+            documentation_url: None,
+            good_first_issues_url: None,
+            stars: None,
+        });
+
+    Allocation {
+        project: UpstreamProject {
+            name: group.label,
+            funding: group.funding,
+            ..representative
+        },
+        amount: (amount * 100.0).round() / 100.0,
+        every_n_months,
+        via,
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::FundingChannel;
+
+    fn make_budget(amount: f64, cadence: Cadence) -> BudgetConfig {
+        BudgetConfig {
+            amount: Some(amount),
+            currency: "USD".to_string(),
+            cadence,
+        }
+    }
+
+    fn make_group(label: &str, stars: u64, num_projects: usize) -> FundableGroup {
+        let projects: Vec<UpstreamProject> = (0..num_projects)
+            .map(|i| UpstreamProject {
+                name: format!("{label}-pkg-{i}"),
+                repo_url: Some(format!("https://github.com/{label}/repo-{i}")),
+                homepage: None,
+                licenses: vec![],
+                funding: vec![FundingChannel {
+                    platform: "GitHub Sponsors".to_string(),
+                    url: format!("https://github.com/sponsors/{label}"),
+                }],
+                bug_tracker: None,
+                contributing_url: None,
+                is_open_source: None,
+                documentation_url: None,
+                good_first_issues_url: None,
+                stars: Some(stars / num_projects.max(1) as u64),
+            })
+            .collect();
+
+        FundableGroup {
+            label: label.to_string(),
+            projects,
+            funding: vec![FundingChannel {
+                platform: "GitHub Sponsors".to_string(),
+                url: format!("https://github.com/sponsors/{label}"),
+            }],
+            total_stars: stars,
+        }
+    }
+
+    #[test]
+    fn equal_plan_divides_evenly() {
+        let budget = make_budget(30.0, Cadence::Monthly);
+        let groups = vec![
+            make_group("alpha", 100, 2),
+            make_group("beta", 200, 1),
+            make_group("gamma", 50, 3),
+        ];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Equal);
+        assert_eq!(plan.allocations.len(), 3);
+        for alloc in &plan.allocations {
+            assert!((alloc.amount - 10.0).abs() < 0.01);
+            assert_eq!(alloc.every_n_months, 1);
+        }
+    }
+
+    #[test]
+    fn weighted_plan_by_stars() {
+        let budget = make_budget(100.0, Cadence::Monthly);
+        let groups = vec![make_group("small", 10, 1), make_group("big", 90, 1)];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Weighted);
+        assert_eq!(plan.allocations.len(), 2);
+
+        let small = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "small")
+            .unwrap();
+        let big = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "big")
+            .unwrap();
+
+        assert!((small.amount - 10.0).abs() < 0.01);
+        assert!((big.amount - 90.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn yearly_cadence_sets_every_12_months() {
+        let budget = make_budget(120.0, Cadence::Yearly);
+        let groups = vec![make_group("proj", 50, 1)];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Equal);
+        assert_eq!(plan.allocations.len(), 1);
+        assert_eq!(plan.allocations[0].every_n_months, 12);
+    }
+
+    #[test]
+    fn group_with_zero_stars_gets_minimum_weight() {
+        let budget = make_budget(100.0, Cadence::Monthly);
+        let groups = vec![
+            make_group("zero-stars", 0, 1),
+            make_group("some-stars", 99, 1),
+        ];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Weighted);
+        assert_eq!(plan.allocations.len(), 2);
+
+        let zero = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "zero-stars")
+            .unwrap();
+        let some = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "some-stars")
+            .unwrap();
+
+        // zero-stars gets weight 1, some-stars gets weight 99, total weight 100
+        assert!((zero.amount - 1.0).abs() < 0.01);
+        assert!((some.amount - 99.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn empty_groups_produces_empty_plan() {
+        let budget = make_budget(100.0, Cadence::Monthly);
+        let plan = generate_plan(&budget, vec![], AllocationStrategy::Equal);
+        assert!(plan.allocations.is_empty());
+    }
+
+    #[test]
+    fn zero_budget_produces_empty_plan() {
+        let budget = make_budget(0.0, Cadence::Monthly);
+        let groups = vec![make_group("proj", 50, 1)];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Equal);
+        assert!(plan.allocations.is_empty());
+    }
+
+    #[test]
+    fn allocation_has_via_from_funding() {
+        let budget = make_budget(10.0, Cadence::Monthly);
+        let groups = vec![make_group("proj", 50, 1)];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Equal);
+        assert_eq!(
+            plan.allocations[0].via.as_deref(),
+            Some("https://github.com/sponsors/proj")
+        );
+    }
+
+    #[test]
+    fn reason_reflects_package_count() {
+        let budget = make_budget(10.0, Cadence::Monthly);
+        let groups = vec![make_group("single", 10, 1), make_group("multi", 10, 3)];
+        let plan = generate_plan(&budget, groups, AllocationStrategy::Equal);
+
+        let single = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "single")
+            .unwrap();
+        let multi = plan
+            .allocations
+            .iter()
+            .find(|a| a.project.name == "multi")
+            .unwrap();
+
+        assert_eq!(single.reason.as_deref(), Some("1 installed package"));
+        assert_eq!(multi.reason.as_deref(), Some("3 installed packages"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
-use syld::config::Config;
+use syld::budget::{self, FundableGroup};
+use syld::config::{BudgetConfig, Cadence, Config};
 use syld::discover::{self, InstalledPackage};
 use syld::enrich::EnrichmentMap;
-use syld::report::{ContributionMap, html, json, terminal};
+use syld::project::FundingChannel;
+use syld::report::{ContributionMap, html, json, lookup_enrichment, terminal};
 use syld::storage::Storage;
 
 #[derive(Parser)]
@@ -264,8 +266,213 @@ fn cmd_cache(command: &CacheCommands) -> Result<()> {
     }
 }
 
-fn cmd_budget(_config: &Config, _command: &BudgetCommands) -> Result<()> {
-    eprintln!("Budget management not yet implemented.");
+fn cmd_budget(config: &Config, command: &BudgetCommands) -> Result<()> {
+    match command {
+        BudgetCommands::Set { amount, cadence } => cmd_budget_set(config, *amount, cadence),
+        BudgetCommands::Show => cmd_budget_show(),
+        BudgetCommands::Plan { strategy } => cmd_budget_plan(config, strategy),
+    }
+}
+
+fn cmd_budget_set(config: &Config, amount: f64, cadence: &BudgetCadence) -> Result<()> {
+    let storage = Storage::open().context("Failed to open database")?;
+    let budget = BudgetConfig {
+        amount: Some(amount),
+        currency: config.budget.currency.clone(),
+        cadence: match cadence {
+            BudgetCadence::Monthly => Cadence::Monthly,
+            BudgetCadence::Yearly => Cadence::Yearly,
+        },
+    };
+    storage.save_budget(&budget)?;
+    let cadence_label = match cadence {
+        BudgetCadence::Monthly => "monthly",
+        BudgetCadence::Yearly => "yearly",
+    };
+    eprintln!(
+        "Budget set: {} {} {}",
+        budget.currency, amount, cadence_label
+    );
+    Ok(())
+}
+
+fn cmd_budget_show() -> Result<()> {
+    let storage = Storage::open().context("Failed to open database")?;
+    match storage.get_budget()? {
+        None => {
+            eprintln!("No budget configured. Use `syld budget set <amount>` to set one.");
+        }
+        Some(budget) => {
+            let cadence_label = match budget.cadence {
+                Cadence::Monthly => "monthly",
+                Cadence::Yearly => "yearly",
+            };
+            match budget.amount {
+                Some(amount) => {
+                    println!("{} {:.2} {}", budget.currency, amount, cadence_label);
+                }
+                None => {
+                    println!(
+                        "Budget configured but no amount set. Use `syld budget set <amount>`."
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_budget_plan(config: &Config, strategy: &AllocationStrategy) -> Result<()> {
+    let storage = Storage::open().context("Failed to open database")?;
+
+    // Load budget
+    let budget = match storage.get_budget()? {
+        Some(b) if b.amount.is_some() => b,
+        _ => {
+            eprintln!("No budget configured. Use `syld budget set <amount>` first.");
+            return Ok(());
+        }
+    };
+
+    // Load latest scan; auto-scan if none
+    let scan = match storage.latest_scan()? {
+        Some(s) => s,
+        None => {
+            eprintln!("No previous scan found. Running scan first\u{2026}");
+            run_scan(config)?;
+            match storage.latest_scan()? {
+                Some(s) => s,
+                None => {
+                    eprintln!("Scan completed but no data was saved.");
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    // Try loading cached enrichment data for each package
+    let mut enrichment = EnrichmentMap::new();
+    for pkg in &scan.packages {
+        if let Some(url) = &pkg.url {
+            let normalized = terminal::normalize_url(url);
+            if !normalized.is_empty()
+                && let Ok(Some(proj)) = storage.get_enrichment(url)
+            {
+                enrichment.insert(normalized, proj);
+            }
+        }
+    }
+
+    // If no enrichment data found, auto-trigger enrichment
+    if enrichment.is_empty() {
+        eprintln!("No enrichment data found. Running enriched scan\u{2026}");
+        enrichment = syld::enrich::enrich_packages(&scan.packages, &storage, config, false, None)?;
+    }
+
+    // Group packages by org/ancestor
+    let groups = terminal::group_by_project(&scan.packages);
+
+    // Build fundable groups from those with funding channels
+    let mut fundable_groups: Vec<FundableGroup> = Vec::new();
+    for group in &groups {
+        if group.url.is_empty() {
+            continue;
+        }
+
+        let enriched = lookup_enrichment(&group.url, &group.project_urls, &enrichment);
+        let funding: Vec<FundingChannel> = enriched.map(|e| e.funding.clone()).unwrap_or_default();
+
+        if funding.is_empty() {
+            continue;
+        }
+
+        let total_stars: u64 = enriched.and_then(|e| e.stars).unwrap_or(0);
+
+        // Collect all enriched projects in this group
+        let mut projects = Vec::new();
+        if let Some(proj) = enriched {
+            projects.push(proj.clone());
+        }
+        // Also collect any per-child-url enrichments for ancestor groups
+        for child_url in &group.project_urls {
+            if let Some(proj) = enrichment.get(child_url.as_str())
+                && !projects
+                    .iter()
+                    .any(|p: &syld::project::UpstreamProject| p.repo_url == proj.repo_url)
+            {
+                projects.push(proj.clone());
+            }
+        }
+
+        let label = if group.project_urls.is_empty() {
+            group.url.clone()
+        } else {
+            format!("{}/*", group.url)
+        };
+
+        fundable_groups.push(FundableGroup {
+            label,
+            projects,
+            funding,
+            total_stars,
+        });
+    }
+
+    if fundable_groups.is_empty() {
+        eprintln!("No projects with funding channels found.");
+        eprintln!("Try running `syld report --enrich` to discover funding links.");
+        return Ok(());
+    }
+
+    let strat = match strategy {
+        AllocationStrategy::Equal => budget::AllocationStrategy::Equal,
+        AllocationStrategy::Weighted => budget::AllocationStrategy::Weighted,
+    };
+
+    let plan = budget::generate_plan(&budget, fundable_groups, strat);
+
+    // Display plan as a table
+    let cadence_label = match budget.cadence {
+        Cadence::Monthly => "monthly",
+        Cadence::Yearly => "yearly",
+    };
+
+    println!();
+    println!(
+        "Donation plan: {} {:.2} {}",
+        budget.currency,
+        budget.amount.unwrap_or(0.0),
+        cadence_label
+    );
+
+    let strategy_label = match strategy {
+        AllocationStrategy::Equal => "equal",
+        AllocationStrategy::Weighted => "weighted",
+    };
+    println!("Strategy: {strategy_label}");
+    println!();
+
+    let mut table = comfy_table::Table::new();
+    table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+    table.set_header(vec!["Project", "Amount", "Frequency", "Via"]);
+
+    for alloc in &plan.allocations {
+        let freq = if alloc.every_n_months == 1 {
+            "monthly".to_string()
+        } else {
+            format!("every {} months", alloc.every_n_months)
+        };
+        let via = alloc.via.as_deref().unwrap_or("-");
+        table.add_row(vec![
+            &alloc.project.name,
+            &format!("{} {:.2}", budget.currency, alloc.amount),
+            &freq,
+            via,
+        ]);
+    }
+
+    println!("{table}");
+
     Ok(())
 }
 

--- a/tests/budget_cli.rs
+++ b/tests/budget_cli.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+use syld::config::{BudgetConfig, Cadence};
+use syld::discover::{InstalledPackage, PackageSource};
+use syld::project::{FundingChannel, UpstreamProject};
+use syld::storage::Storage;
+
+fn syld_with_db(config_home: &Path, data_home: &Path) -> Command {
+    let mut cmd: Command = cargo_bin_cmd!("syld").into();
+    cmd.env("XDG_CONFIG_HOME", config_home);
+    cmd.env("XDG_DATA_HOME", data_home);
+    cmd
+}
+
+fn open_storage(data_home: &Path) -> Storage {
+    let db_dir = data_home.join("syld");
+    std::fs::create_dir_all(&db_dir).unwrap();
+    Storage::open_path(&db_dir.join("syld.db")).unwrap()
+}
+
+fn seed_scan(data_home: &Path) {
+    let storage = open_storage(data_home);
+    storage
+        .save_scan(&[
+            InstalledPackage {
+                name: "firefox".to_string(),
+                version: "128.0".to_string(),
+                description: Some("Web browser".to_string()),
+                url: Some("https://github.com/nicotine-plus/nicotine-plus".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["MPL-2.0".to_string()],
+            },
+            InstalledPackage {
+                name: "linux".to_string(),
+                version: "6.9.7".to_string(),
+                description: None,
+                url: Some("https://kernel.org".to_string()),
+                source: PackageSource::Pacman,
+                licenses: vec!["GPL-2.0".to_string()],
+            },
+        ])
+        .unwrap();
+}
+
+fn seed_enrichment_with_funding(data_home: &Path) {
+    let storage = open_storage(data_home);
+    let project = UpstreamProject {
+        name: "nicotine-plus".to_string(),
+        repo_url: Some("https://github.com/nicotine-plus/nicotine-plus".to_string()),
+        homepage: None,
+        licenses: vec!["GPL-3.0".to_string()],
+        funding: vec![FundingChannel {
+            platform: "GitHub Sponsors".to_string(),
+            url: "https://github.com/sponsors/nicotine-plus".to_string(),
+        }],
+        bug_tracker: None,
+        contributing_url: None,
+        is_open_source: Some(true),
+        documentation_url: None,
+        good_first_issues_url: None,
+        stars: Some(500),
+    };
+    storage
+        .save_enrichment("https://github.com/nicotine-plus/nicotine-plus", &project)
+        .unwrap();
+}
+
+#[test]
+fn budget_set_persists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "set", "10"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Budget set:"));
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("USD"))
+        .stdout(predicate::str::contains("10.00"))
+        .stdout(predicate::str::contains("monthly"));
+}
+
+#[test]
+fn budget_set_yearly() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "set", "120", "--cadence", "yearly"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("yearly"));
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("120.00"))
+        .stdout(predicate::str::contains("yearly"));
+}
+
+#[test]
+fn budget_show_when_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "show"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No budget configured"));
+}
+
+#[test]
+fn budget_plan_no_budget() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "plan"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No budget configured"));
+}
+
+#[test]
+fn budget_plan_no_fundable_projects() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+
+    // Set a budget but don't seed any enrichment with funding
+    let storage = open_storage(data.path());
+    storage
+        .save_budget(&BudgetConfig {
+            amount: Some(10.0),
+            currency: "USD".to_string(),
+            cadence: Cadence::Monthly,
+        })
+        .unwrap();
+
+    // Seed enrichment without funding channels
+    let project = UpstreamProject {
+        name: "nicotine-plus".to_string(),
+        repo_url: Some("https://github.com/nicotine-plus/nicotine-plus".to_string()),
+        homepage: None,
+        licenses: vec![],
+        funding: vec![], // no funding
+        bug_tracker: None,
+        contributing_url: None,
+        is_open_source: None,
+        documentation_url: None,
+        good_first_issues_url: None,
+        stars: None,
+    };
+    storage
+        .save_enrichment("https://github.com/nicotine-plus/nicotine-plus", &project)
+        .unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "plan"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "No projects with funding channels found",
+        ));
+}
+
+#[test]
+fn budget_plan_equal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+    seed_enrichment_with_funding(data.path());
+
+    let storage = open_storage(data.path());
+    storage
+        .save_budget(&BudgetConfig {
+            amount: Some(10.0),
+            currency: "USD".to_string(),
+            cadence: Cadence::Monthly,
+        })
+        .unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Donation plan"))
+        .stdout(predicate::str::contains("Strategy: equal"))
+        .stdout(predicate::str::contains("USD"))
+        .stdout(predicate::str::contains("monthly"))
+        .stdout(predicate::str::contains(
+            "github.com/sponsors/nicotine-plus",
+        ));
+}
+
+#[test]
+fn budget_plan_weighted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    seed_scan(data.path());
+    seed_enrichment_with_funding(data.path());
+
+    let storage = open_storage(data.path());
+    storage
+        .save_budget(&BudgetConfig {
+            amount: Some(10.0),
+            currency: "USD".to_string(),
+            cadence: Cadence::Monthly,
+        })
+        .unwrap();
+
+    syld_with_db(tmp.path(), data.path())
+        .args(["budget", "plan", "--strategy", "weighted"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Strategy: weighted"))
+        .stdout(predicate::str::contains("USD"));
+}


### PR DESCRIPTION
## Summary

- Wire up the three `syld budget` subcommands that were previously stubbed out
- `budget set <amount> [--cadence monthly|yearly]` persists budget config to the database
- `budget show` displays current budget or a helpful message when unset
- `budget plan [--strategy equal|weighted]` generates an org-level donation plan by grouping packages via `group_by_project()`, filtering to groups with funding channels, and distributing the budget equally or weighted by star count
- The plan command auto-scans and auto-enriches when no prior data exists, following the same pattern as `syld report`
- Adds `AllocationStrategy` enum, `FundableGroup` struct, and `generate_plan()` logic to `src/budget/mod.rs`

## Test plan

- [x] 8 unit tests for plan generation (equal/weighted allocation, cadence, zero stars, edge cases)
- [x] 7 integration tests for CLI (`budget_set_persists`, `budget_show_when_empty`, `budget_plan_no_budget`, `budget_plan_no_fundable_projects`, `budget_plan_equal`, `budget_plan_weighted`, `budget_set_yearly`)
- [x] Full test suite passes (`cargo test` — 284 tests)
- [x] Manual smoke test: `syld budget set 10 && syld budget show && syld report --enrich && syld budget plan`

Closes #13