### PR TITLE
Add --silent flag to scan command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ enum Commands {
         /// Maximum number of projects to display (0 for all)
         #[arg(long, default_value = "20")]
         limit: usize,
+
+        /// Scan only — save results to the database without printing the summary table
+        #[arg(long)]
+        silent: bool,
     },
 
     /// Generate a report from the last scan
@@ -199,8 +203,8 @@ fn main() -> Result<()> {
     let config = Config::load()?;
 
     match cli.command {
-        None => cmd_scan(&config, 20),
-        Some(Commands::Scan { limit }) => cmd_scan(&config, limit),
+        None => cmd_scan(&config, 20, false),
+        Some(Commands::Scan { limit, silent }) => cmd_scan(&config, limit, silent),
         Some(Commands::Report {
             format,
             enrich,
@@ -251,17 +255,20 @@ fn run_scan(config: &Config) -> Result<Vec<InstalledPackage>> {
     Ok(all_packages)
 }
 
-fn cmd_scan(config: &Config, limit: usize) -> Result<()> {
-    let mut all_packages = run_scan(config)?;
+fn cmd_scan(config: &Config, limit: usize, silent: bool) -> Result<()> {
+    let all_packages = run_scan(config)?;
 
-    terminal::sort_packages(&mut all_packages);
-    terminal::print_summary(
-        &all_packages,
-        limit,
-        chrono::Utc::now(),
-        &ContributionMap::new(),
-        &EnrichmentMap::new(),
-    );
+    if !silent {
+        let mut sorted = all_packages;
+        terminal::sort_packages(&mut sorted);
+        terminal::print_summary(
+            &sorted,
+            limit,
+            chrono::Utc::now(),
+            &ContributionMap::new(),
+            &EnrichmentMap::new(),
+        );
+    }
 
     Ok(())
 }

--- a/tests/install_cli.rs
+++ b/tests/install_cli.rs
@@ -97,6 +97,28 @@ fn install_hook_unknown_name_fails() {
 }
 
 #[test]
+fn scan_silent_produces_no_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["scan", "--silent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn scan_help_shows_silent_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["scan", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--silent"));
+}
+
+#[test]
 fn top_level_help_shows_setup_in_workflow() {
     let tmp = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Adds `--silent` flag to `syld scan` that performs the scan and saves results to the database without printing the summary table
- Progress messages on stderr are still shown so the user knows something is happening
- Default behavior (no flag) is unchanged

Closes #57

## Test plan

- [x] `cargo test` — all tests pass (268 unit + 55 integration)
- [x] `cargo clippy` — no new warnings
- [x] `syld scan --silent` produces no stdout output
- [x] `syld scan --help` shows the `--silent` flag
- [x] `syld scan` (without flag) — unchanged behavior