### PR TITLE
Remove --enrich flag from report, use configuration only

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ syld scan --limit 50        # show more results (0 for all)
 ### 3. Review
 
 ```sh
-syld report                 # terminal report from last scan
-syld report --enrich        # fetch donation links, stars, etc.
+syld report                 # terminal report from last scan (enriches if configured)
+syld report --force-refresh # re-fetch enrichment data, bypassing cache
 syld report --format json   # machine-readable output
 syld report --format html   # HTML report
 ```
@@ -119,7 +119,7 @@ syld budget plan --strategy weighted
 
 ### 5. Hooks
 
-Package manager hooks surface contribution opportunities after transactions. A prior `syld scan` + `syld report --enrich` is needed for the hook to have data.
+Package manager hooks surface contribution opportunities after transactions. A prior `syld scan` + `syld report` (with `enrich = true` in config) is needed for the hook to have data.
 
 ```sh
 syld hook list                      # show available hooks
@@ -164,7 +164,7 @@ mise run lint         # auto-fix clippy warnings
 syld respects your privacy:
 
 - **Default mode**: reads only local package databases. Zero network access.
-- **Enriched mode** (`--enrich`): opt-in only. Fetches project metadata from public sources (GitHub, GitLab, Open Collective, Liberapay). No personal data is sent.
+- **Enriched mode** (`enrich = true` in config): opt-in only. Fetches project metadata from public sources (GitHub, GitLab, Open Collective, Liberapay). No personal data is sent.
 - No telemetry, no tracking, no accounts.
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,13 +53,9 @@ enum Commands {
         #[arg(long, default_value = "terminal")]
         format: ReportFormat,
 
-        /// Fetch additional info from the network (donation links, etc.)
+        /// Force re-enrichment, bypassing the cache
         #[arg(long)]
-        enrich: bool,
-
-        /// Force re-enrichment, bypassing the cache (implies --enrich)
-        #[arg(long)]
-        force_enrich: bool,
+        force_refresh: bool,
 
         /// Number of parallel enrichment threads
         #[arg(short = 'j', long)]
@@ -207,10 +203,9 @@ fn main() -> Result<()> {
         Some(Commands::Scan { limit, silent }) => cmd_scan(&config, limit, silent),
         Some(Commands::Report {
             format,
-            enrich,
-            force_enrich,
+            force_refresh,
             jobs,
-        }) => cmd_report(&config, &format, enrich, force_enrich, jobs),
+        }) => cmd_report(&config, &format, force_refresh, jobs),
         Some(Commands::Cache { command }) => cmd_cache(&command),
         Some(Commands::Budget { command }) => cmd_budget(&config, &command),
         Some(Commands::Config { command }) => cmd_config(&config, &command),
@@ -288,8 +283,7 @@ fn cmd_scan(config: &Config, limit: usize, silent: bool) -> Result<()> {
 fn cmd_report(
     config: &Config,
     format: &ReportFormat,
-    enrich: bool,
-    force_enrich: bool,
+    force_refresh: bool,
     jobs: Option<usize>,
 ) -> Result<()> {
     let storage = Storage::open().context("Failed to open database")?;
@@ -315,10 +309,9 @@ fn cmd_report(
         }
     };
 
-    // Run enrichment if requested via CLI flag or config
-    // --force-enrich implies --enrich
-    let enrichment = if enrich || force_enrich || config.enrich {
-        syld::enrich::enrich_packages(&scan.packages, &storage, config, force_enrich, jobs)?
+    // Run enrichment if enabled in config; --force-refresh bypasses cache
+    let enrichment = if config.enrich || force_refresh {
+        syld::enrich::enrich_packages(&scan.packages, &storage, config, force_refresh, jobs)?
     } else {
         syld::enrich::EnrichmentMap::new()
     };


### PR DESCRIPTION
## Summary

- Removes `--enrich` flag from `syld report` — enrichment is now controlled solely by the `enrich` config key
- Renames `--force-enrich` to `--force-refresh` for clarity (bypasses cache, implies enrichment)
- Updates README references

Closes #60

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no new warnings
- [x] `syld report --help` — no `--enrich` flag, shows `--force-refresh`
- [x] `syld report` with `enrich = true` in config — enriches automatically
- [x] `syld report` with `enrich = false` — no enrichment
- [x] `syld report --force-refresh` — enriches regardless of config, bypasses cache