### PR TITLE
Refactor CI to use mise-action and mise tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-
-      - run: cargo fmt --check
-      - run: cargo clippy -- -D warnings
-      - run: cargo test
-      - run: cargo build
+      - uses: jdx/mise-action@v2
+      - run: mise run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - uses: jdx/mise-action@v2
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install cross
         if: matrix.cross


### PR DESCRIPTION
## Summary

- Replace `dtolnay/rust-toolchain` and `Swatinem/rust-cache` with `jdx/mise-action@v2` in both CI and release workflows
- CI now runs `mise run check` instead of duplicating individual `cargo` commands
- Single source of truth for tool versions and task definitions via `mise.toml`

## Changes

**`ci.yml`**: Simplified from 7 steps to 3 — checkout, mise-action, `mise run check`. Tool installation and caching are handled by mise-action.

**`release.yml`**: Replaced `dtolnay/rust-toolchain` with `jdx/mise-action@v2`. Added explicit `rustup target add` step since mise installs the stable toolchain without extra targets. Cross-compilation and release logic unchanged.

## Test plan

- [x] CI workflow passes on this PR (fmt, clippy, test, build via `mise run check`)
- [x] Verify mise-action installs Rust and components correctly

Closes #71