### PR TITLE
Add contribution summary to report output

### DIFF
--- a/schemas/report.v1.json
+++ b/schemas/report.v1.json
@@ -50,6 +50,10 @@
       "items": {
         "$ref": "#/$defs/package"
       }
+    },
+    "contributions_summary": {
+      "$ref": "#/$defs/contributions_summary",
+      "description": "Aggregated summary of the user's contribution history. Omitted when there are no contributions."
     }
   },
   "$defs": {
@@ -155,6 +159,53 @@
           "type": "string",
           "format": "uri",
           "description": "URL the user can visit to act on this opportunity."
+        }
+      }
+    },
+    "contributions_summary": {
+      "type": "object",
+      "title": "ContributionSummary",
+      "description": "Aggregated summary of the user's contribution history.",
+      "required": ["stars", "issues", "pull_requests", "donations", "docs", "other"],
+      "additionalProperties": false,
+      "properties": {
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of projects starred."
+        },
+        "issues": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of issues filed."
+        },
+        "pull_requests": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of pull requests submitted."
+        },
+        "donations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of projects donated to."
+        },
+        "donation_total": {
+          "type": ["number", "null"],
+          "description": "Total donation amount, or null if donations use mixed currencies."
+        },
+        "donation_currency": {
+          "type": ["string", "null"],
+          "description": "Currency of the donation total, or null if mixed."
+        },
+        "docs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of documentation contributions."
+        },
+        "other": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of other contributions."
         }
       }
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use syld::discover::{self, InstalledPackage};
 use syld::enrich::EnrichmentMap;
 use syld::hook::{self, HookContext};
 use syld::install;
-use syld::report::{ContributionMap, html, json, terminal};
+use syld::report::{ContributionMap, ContributionSummary, html, json, terminal};
 use syld::storage::Storage;
 
 #[derive(Parser)]
@@ -229,6 +229,7 @@ fn cmd_scan(config: &Config, limit: usize, silent: bool) -> Result<()> {
             chrono::Utc::now(),
             &ContributionMap::new(),
             &EnrichmentMap::new(),
+            None,
         );
     }
 
@@ -272,17 +273,43 @@ fn cmd_report(
     };
     let contributions = ContributionMap::new();
 
+    // Build contribution summary from stored records
+    let contribution_summary = storage
+        .get_contributions(None, None)
+        .ok()
+        .map(|records| ContributionSummary::from_records(&records))
+        .filter(|s| !s.is_empty());
+
     match format {
         ReportFormat::Terminal => {
             let mut packages = scan.packages;
             terminal::sort_packages(&mut packages);
-            terminal::print_summary(&packages, 0, scan.timestamp, &contributions, &enrichment);
+            terminal::print_summary(
+                &packages,
+                0,
+                scan.timestamp,
+                &contributions,
+                &enrichment,
+                contribution_summary.as_ref(),
+            );
         }
         ReportFormat::Json => {
-            json::print_json(&scan.packages, scan.timestamp, &contributions, &enrichment)?;
+            json::print_json(
+                &scan.packages,
+                scan.timestamp,
+                &contributions,
+                &enrichment,
+                contribution_summary,
+            )?;
         }
         ReportFormat::Html => {
-            html::print_html(&scan.packages, scan.timestamp, &contributions, &enrichment);
+            html::print_html(
+                &scan.packages,
+                scan.timestamp,
+                &contributions,
+                &enrichment,
+                contribution_summary.as_ref(),
+            );
         }
     }
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use crate::discover::{InstalledPackage, PackageSource};
 use crate::enrich::EnrichmentMap;
 use crate::report::terminal::{group_by_project, sort_packages};
-use crate::report::{ContributionMap, lookup_contributions, lookup_enrichment};
+use crate::report::{
+    ContributionMap, ContributionSummary, lookup_contributions, lookup_enrichment,
+};
 
 /// Escape HTML special characters.
 fn escape_html(s: &str) -> String {
@@ -39,6 +41,7 @@ pub fn print_html(
     timestamp: DateTime<Utc>,
     contributions: &ContributionMap,
     enrichment: &EnrichmentMap,
+    contribution_summary: Option<&ContributionSummary>,
 ) {
     let mut sorted = packages.to_vec();
     sort_packages(&mut sorted);
@@ -192,6 +195,51 @@ pub fn print_html(
         if has_any {
             html.push_str("</table>\n");
         }
+    }
+
+    // Your Contributions section
+    if let Some(summary) = contribution_summary
+        && !summary.is_empty()
+    {
+        html.push_str("<h2>Your Contributions</h2>\n");
+        html.push_str("<ul>\n");
+        if summary.stars > 0 {
+            html.push_str(&format!("<li>{} projects starred</li>\n", summary.stars));
+        }
+        if summary.issues > 0 {
+            html.push_str(&format!("<li>{} issues filed</li>\n", summary.issues));
+        }
+        if summary.pull_requests > 0 {
+            html.push_str(&format!(
+                "<li>{} pull requests submitted</li>\n",
+                summary.pull_requests
+            ));
+        }
+        if summary.docs > 0 {
+            html.push_str(&format!(
+                "<li>{} documentation improvements</li>\n",
+                summary.docs
+            ));
+        }
+        if summary.donations > 0 {
+            if let (Some(total), Some(currency)) =
+                (summary.donation_total, &summary.donation_currency)
+            {
+                html.push_str(&format!(
+                    "<li>{} projects donated to ({} {:.2} total)</li>\n",
+                    summary.donations, currency, total
+                ));
+            } else {
+                html.push_str(&format!(
+                    "<li>{} projects donated to</li>\n",
+                    summary.donations
+                ));
+            }
+        }
+        if summary.other > 0 {
+            html.push_str(&format!("<li>{} other contributions</li>\n", summary.other));
+        }
+        html.push_str("</ul>\n");
     }
 
     // Funding section

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -9,7 +9,9 @@ use crate::discover::InstalledPackage;
 use crate::enrich::EnrichmentMap;
 use crate::project::FundingChannel;
 use crate::report::terminal::group_by_project;
-use crate::report::{ContributionMap, lookup_contributions, lookup_enrichment};
+use crate::report::{
+    ContributionMap, ContributionSummary, lookup_contributions, lookup_enrichment,
+};
 
 /// A grouped upstream project for the JSON report.
 #[derive(Serialize)]
@@ -47,6 +49,8 @@ pub struct JsonReport {
     pub total_contribution_opportunities: usize,
     pub projects: Vec<JsonProject>,
     pub packages: Vec<InstalledPackage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contributions_summary: Option<ContributionSummary>,
 }
 
 /// Generate a JSON report and print it to stdout.
@@ -55,6 +59,7 @@ pub fn print_json(
     timestamp: DateTime<Utc>,
     contributions: &ContributionMap,
     enrichment: &EnrichmentMap,
+    contribution_summary: Option<ContributionSummary>,
 ) -> Result<()> {
     let groups = group_by_project(packages);
     let total_projects = groups.iter().filter(|g| !g.url.is_empty()).count();
@@ -98,6 +103,7 @@ pub fn print_json(
         total_contribution_opportunities,
         projects,
         packages: packages.to_vec(),
+        contributions_summary: contribution_summary,
     };
 
     let json = serde_json::to_string_pretty(&report)?;
@@ -164,6 +170,7 @@ mod tests {
                 },
             ],
             packages: packages.clone(),
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -194,6 +201,7 @@ mod tests {
             total_contribution_opportunities: 0,
             projects: vec![],
             packages: vec![],
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -227,6 +235,7 @@ mod tests {
             total_contribution_opportunities: 0,
             projects: vec![],
             packages,
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -280,6 +289,7 @@ mod tests {
                 },
             ],
             packages,
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -303,6 +313,7 @@ mod tests {
             total_contribution_opportunities: 0,
             projects: vec![],
             packages: vec![],
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -334,6 +345,7 @@ mod tests {
             total_contribution_opportunities: 0,
             projects: vec![],
             packages,
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -392,6 +404,7 @@ mod tests {
                 },
             ],
             packages: packages.clone(),
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -441,6 +454,7 @@ mod tests {
                 }],
             }],
             packages,
+            contributions_summary: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();
@@ -471,7 +485,7 @@ mod tests {
 
         // Just verify it doesn't panic — output goes to stdout
         let enrichment = EnrichmentMap::new();
-        let result = print_json(&packages, timestamp, &contributions, &enrichment);
+        let result = print_json(&packages, timestamp, &contributions, &enrichment, None);
         assert!(result.is_ok());
     }
 
@@ -482,7 +496,7 @@ mod tests {
         let contributions = ContributionMap::new();
         let enrichment = EnrichmentMap::new();
 
-        let result = print_json(&packages, timestamp, &contributions, &enrichment);
+        let result = print_json(&packages, timestamp, &contributions, &enrichment, None);
         assert!(result.is_ok());
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -4,7 +4,9 @@
 
 use std::collections::HashMap;
 
-use crate::contribute::ContributionOpportunity;
+use serde::Serialize;
+
+use crate::contribute::{ContributionOpportunity, ContributionRecord, ContributionRecordKind};
 use crate::enrich::EnrichmentMap;
 use crate::project::UpstreamProject;
 
@@ -17,6 +19,77 @@ pub mod terminal;
 /// Report functions accept this as an optional parameter so they can display
 /// a "Ways to Help" section alongside the existing package/project tables.
 pub type ContributionMap = HashMap<String, Vec<ContributionOpportunity>>;
+
+/// Aggregated summary of the user's contribution history.
+#[derive(Debug, Default, Serialize)]
+pub struct ContributionSummary {
+    /// Number of projects starred.
+    pub stars: usize,
+    /// Number of issues filed.
+    pub issues: usize,
+    /// Number of pull requests submitted.
+    pub pull_requests: usize,
+    /// Number of projects donated to.
+    pub donations: usize,
+    /// Total donation amount (if all donations share a currency).
+    pub donation_total: Option<f64>,
+    /// Currency of the donation total.
+    pub donation_currency: Option<String>,
+    /// Number of documentation contributions.
+    pub docs: usize,
+    /// Number of other contributions.
+    pub other: usize,
+}
+
+impl ContributionSummary {
+    /// Build a summary from a list of contribution records.
+    pub fn from_records(records: &[ContributionRecord]) -> Self {
+        let mut summary = Self::default();
+        let mut donation_amounts: HashMap<String, f64> = HashMap::new();
+
+        for record in records {
+            match record.kind {
+                ContributionRecordKind::Star => summary.stars += 1,
+                ContributionRecordKind::Issue => summary.issues += 1,
+                ContributionRecordKind::PullRequest => summary.pull_requests += 1,
+                ContributionRecordKind::Donation => {
+                    summary.donations += 1;
+                    // Parse amount from title like "10 USD via GitHub Sponsors" or "25 EUR"
+                    if let Some(title) = &record.title {
+                        let parts: Vec<&str> = title.split_whitespace().collect();
+                        if parts.len() >= 2
+                            && let Ok(amount) = parts[0].parse::<f64>()
+                        {
+                            let currency = parts[1].to_string();
+                            *donation_amounts.entry(currency).or_default() += amount;
+                        }
+                    }
+                }
+                ContributionRecordKind::Docs => summary.docs += 1,
+                ContributionRecordKind::Other => summary.other += 1,
+            }
+        }
+
+        // Set total only if all donations use the same currency
+        if donation_amounts.len() == 1 {
+            let (currency, total) = donation_amounts.into_iter().next().unwrap();
+            summary.donation_total = Some(total);
+            summary.donation_currency = Some(currency);
+        }
+
+        summary
+    }
+
+    /// Whether the summary has any contributions at all.
+    pub fn is_empty(&self) -> bool {
+        self.stars == 0
+            && self.issues == 0
+            && self.pull_requests == 0
+            && self.donations == 0
+            && self.docs == 0
+            && self.other == 0
+    }
+}
 
 /// Look up contributions for a project group, checking both the group URL and
 /// any individual project URLs within an ancestor group.
@@ -66,6 +139,7 @@ pub fn lookup_enrichment<'a>(
 mod tests {
     use super::*;
     use crate::contribute::ContributionKind;
+    use chrono::Utc;
 
     fn make_opp(kind: ContributionKind, title: &str) -> ContributionOpportunity {
         ContributionOpportunity {
@@ -137,5 +211,66 @@ mod tests {
 
         let result = lookup_contributions("github.com/foo", &[], &map);
         assert!(result.is_empty());
+    }
+
+    fn make_record(kind: ContributionRecordKind, title: Option<&str>) -> ContributionRecord {
+        ContributionRecord {
+            id: 0,
+            project_url: "https://github.com/example".to_string(),
+            kind,
+            title: title.map(|s| s.to_string()),
+            url: None,
+            contributed_at: Utc::now(),
+            source: None,
+        }
+    }
+
+    #[test]
+    fn contribution_summary_from_records() {
+        let records = vec![
+            make_record(ContributionRecordKind::Star, None),
+            make_record(ContributionRecordKind::Star, None),
+            make_record(ContributionRecordKind::Issue, Some("Fix bug")),
+            make_record(ContributionRecordKind::PullRequest, Some("Add feature")),
+            make_record(
+                ContributionRecordKind::Donation,
+                Some("10 USD via GitHub Sponsors"),
+            ),
+            make_record(ContributionRecordKind::Donation, Some("25 USD")),
+            make_record(ContributionRecordKind::Docs, Some("Improve README")),
+        ];
+
+        let summary = ContributionSummary::from_records(&records);
+        assert_eq!(summary.stars, 2);
+        assert_eq!(summary.issues, 1);
+        assert_eq!(summary.pull_requests, 1);
+        assert_eq!(summary.donations, 2);
+        assert_eq!(summary.donation_total, Some(35.0));
+        assert_eq!(summary.donation_currency, Some("USD".to_string()));
+        assert_eq!(summary.docs, 1);
+        assert_eq!(summary.other, 0);
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn contribution_summary_empty() {
+        let summary = ContributionSummary::from_records(&[]);
+        assert!(summary.is_empty());
+        assert_eq!(summary.stars, 0);
+        assert!(summary.donation_total.is_none());
+    }
+
+    #[test]
+    fn contribution_summary_mixed_currencies() {
+        let records = vec![
+            make_record(ContributionRecordKind::Donation, Some("10 USD")),
+            make_record(ContributionRecordKind::Donation, Some("25 EUR")),
+        ];
+
+        let summary = ContributionSummary::from_records(&records);
+        assert_eq!(summary.donations, 2);
+        // Mixed currencies — no total
+        assert!(summary.donation_total.is_none());
+        assert!(summary.donation_currency.is_none());
     }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -7,7 +7,9 @@ use comfy_table::{ContentArrangement, Table};
 
 use crate::discover::{InstalledPackage, PackageSource};
 use crate::enrich::EnrichmentMap;
-use crate::report::{ContributionMap, lookup_contributions, lookup_enrichment};
+use crate::report::{
+    ContributionMap, ContributionSummary, lookup_contributions, lookup_enrichment,
+};
 
 /// Sort packages alphabetically by name (case-insensitive), then by source.
 pub fn sort_packages(packages: &mut [InstalledPackage]) {
@@ -160,6 +162,7 @@ pub fn print_summary(
     timestamp: DateTime<Utc>,
     contributions: &ContributionMap,
     enrichment: &EnrichmentMap,
+    contribution_summary: Option<&ContributionSummary>,
 ) {
     if packages.is_empty() {
         println!("No packages found.");
@@ -303,6 +306,44 @@ pub fn print_summary(
             }
 
             println!("{help_table}");
+        }
+    }
+
+    // Your Contributions section
+    if let Some(summary) = contribution_summary
+        && !summary.is_empty()
+    {
+        println!();
+        println!(
+            "Your open source contributions ({}):",
+            timestamp.format("%Y")
+        );
+        if summary.stars > 0 {
+            println!("  {:>3} projects starred", summary.stars);
+        }
+        if summary.issues > 0 {
+            println!("  {:>3} issues filed", summary.issues);
+        }
+        if summary.pull_requests > 0 {
+            println!("  {:>3} pull requests submitted", summary.pull_requests);
+        }
+        if summary.docs > 0 {
+            println!("  {:>3} documentation improvements", summary.docs);
+        }
+        if summary.donations > 0 {
+            if let (Some(total), Some(currency)) =
+                (summary.donation_total, &summary.donation_currency)
+            {
+                println!(
+                    "  {:>3} projects donated to ({} {:.2} total)",
+                    summary.donations, currency, total
+                );
+            } else {
+                println!("  {:>3} projects donated to", summary.donations);
+            }
+        }
+        if summary.other > 0 {
+            println!("  {:>3} other contributions", summary.other);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `ContributionSummary` type in `report/mod.rs` that aggregates contribution records into counts per kind (stars, issues, PRs, donations, docs, other) with optional donation totals
- Display "Your Contributions" section in all three report formats:
  - **Terminal**: human-readable summary with aligned counts
  - **JSON**: optional `contributions_summary` object with all fields
  - **HTML**: `<h2>Your Contributions</h2>` with `<ul>` list
- Query contributions from database in `cmd_report` and pass through to formatters
- Update JSON schema (`schemas/report.v1.json`) with `contributions_summary` definition
- Empty contributions are handled gracefully (section is omitted)

## Example terminal output

```
Your open source contributions (2026):
   35 projects starred
    4 issues filed
    2 pull requests submitted
    5 documentation improvements
    4 projects donated to (USD 48.00 total)
```

## Test plan

- [x] 3 new unit tests for `ContributionSummary::from_records` (basic, empty, mixed currencies)
- [x] All 290 tests pass
- [x] Clippy clean, fmt clean

Closes #75