### PR TITLE
Hide hook subcommand from CLI help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,8 @@ enum Commands {
         command: Option<ConfigCommands>,
     },
 
-    /// Manage package manager hooks
+    /// Manage package manager hooks (internal plumbing for ALPM hook integration)
+    #[command(hide = true)]
     Hook {
         #[command(subcommand)]
         command: HookCommands,


### PR DESCRIPTION
## Summary
- Hides the `hook` subcommand from `syld --help` output using clap's `hide = true`
- The command remains fully functional — the ALPM hook file continues to call `syld hook run pacman-post-transaction` as before

## Investigation findings (closes #79)

The `hook` subcommand serves as **internal plumbing** for package manager integration:

- `syld hook run <name>` is the entry point called by the pacman ALPM hook file after installs/upgrades. It reads package names from stdin, checks the local enrichment cache, and prints up to 3 funding links to stderr. **This is necessary** — removing it would break pacman integration.
- `syld hook list` is a minor debugging aid showing registered hooks and their availability.

The hook *system* is valuable (surfacing funding at install time is a compelling feature), but the CLI subcommand is not meant for direct user interaction. Hiding it from help keeps the CLI clean while preserving full functionality.

## Test plan
- [x] `cargo test` passes (all 17 integration + unit tests)
- [x] `syld --help` no longer shows `hook`
- [x] `syld hook list` and `syld hook run` still work