### PR TITLE
Fix unbound variables in release task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -45,9 +45,9 @@ set -euo pipefail
 
 # --- Validate flags ---
 count=0
-[[ "${usage_major}" == "true" ]] && count=$((count + 1))
-[[ "${usage_minor}" == "true" ]] && count=$((count + 1))
-[[ "${usage_patch}" == "true" ]] && count=$((count + 1))
+[[ "${usage_major:-false}" == "true" ]] && count=$((count + 1))
+[[ "${usage_minor:-false}" == "true" ]] && count=$((count + 1))
+[[ "${usage_patch:-false}" == "true" ]] && count=$((count + 1))
 
 if [[ "$count" -ne 1 ]]; then
   echo "Error: exactly one of --major, --minor, or --patch must be provided" >&2
@@ -75,9 +75,9 @@ fi
 current_version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
 IFS='.' read -r major minor patch <<< "$current_version"
 
-if [[ "${usage_major}" == "true" ]]; then
+if [[ "${usage_major:-false}" == "true" ]]; then
   major=$((major + 1)); minor=0; patch=0
-elif [[ "${usage_minor}" == "true" ]]; then
+elif [[ "${usage_minor:-false}" == "true" ]]; then
   minor=$((minor + 1)); patch=0
 else
   patch=$((patch + 1))


### PR DESCRIPTION
## Summary
- The release task script uses `set -euo pipefail`, but the mise usage flag variables (`usage_major`, `usage_minor`, `usage_patch`) are only set when their corresponding flag is passed
- Running e.g. `mise run release --minor` fails with `usage_major: unbound variable` because bash's `-u` flag treats unset variables as errors
- Added `:-false` default values to all references of these variables

## Test plan
- [ ] Run `mise run release --minor` (on a non-main branch or with a dry-run) and verify no unbound variable error