### PR TITLE
Add `syld contribute` command scaffolding

### DIFF
--- a/src/contribute/mod.rs
+++ b/src/contribute/mod.rs
@@ -111,6 +111,7 @@
 
 pub mod github_good_first_issues;
 pub mod github_sync;
+pub mod suggest;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};

--- a/src/contribute/suggest.rs
+++ b/src/contribute/suggest.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Contribution suggestion engine for the `syld contribute` command.
+//!
+//! This module defines the types used to generate actionable suggestions
+//! from scan and enrichment data.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// The category of a contribution suggestion.
+///
+/// These map to the `--type` flag values on the `contribute` command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestionKind {
+    /// Star the project on GitHub.
+    Star,
+    /// Check good first issues.
+    Issue,
+    /// Donate via a funding channel.
+    Donate,
+    /// Improve project documentation.
+    Docs,
+    /// Share a lesser-known project.
+    Spread,
+}
+
+impl SuggestionKind {
+    /// All known suggestion kinds.
+    pub const ALL: &[SuggestionKind] = &[
+        SuggestionKind::Star,
+        SuggestionKind::Issue,
+        SuggestionKind::Donate,
+        SuggestionKind::Docs,
+        SuggestionKind::Spread,
+    ];
+
+    /// The emoji used when displaying this suggestion kind.
+    pub fn emoji(self) -> &'static str {
+        match self {
+            SuggestionKind::Star => "\u{2b50}",
+            SuggestionKind::Issue => "\u{1f41b}",
+            SuggestionKind::Donate => "\u{1f4b0}",
+            SuggestionKind::Docs => "\u{1f4d6}",
+            SuggestionKind::Spread => "\u{1f4e3}",
+        }
+    }
+}
+
+impl fmt::Display for SuggestionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SuggestionKind::Star => write!(f, "star"),
+            SuggestionKind::Issue => write!(f, "issue"),
+            SuggestionKind::Donate => write!(f, "donate"),
+            SuggestionKind::Docs => write!(f, "docs"),
+            SuggestionKind::Spread => write!(f, "spread"),
+        }
+    }
+}
+
+impl FromStr for SuggestionKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "star" => Ok(SuggestionKind::Star),
+            "issue" => Ok(SuggestionKind::Issue),
+            "donate" => Ok(SuggestionKind::Donate),
+            "docs" => Ok(SuggestionKind::Docs),
+            "spread" => Ok(SuggestionKind::Spread),
+            _ => Err(format!(
+                "unknown suggestion type '{s}'. Valid types: star, issue, donate, docs, spread"
+            )),
+        }
+    }
+}
+
+/// A concrete, actionable contribution suggestion shown to the user.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContributionSuggestion {
+    /// What category of contribution this is.
+    pub kind: SuggestionKind,
+
+    /// Human-readable action description (e.g. "Star curl/curl on GitHub").
+    pub title: String,
+
+    /// URL the user can visit to act on this suggestion.
+    pub url: String,
+}
+
+/// Parse a comma-separated list of suggestion types.
+///
+/// Returns an error message if any type is unrecognised.
+pub fn parse_types(input: &str) -> Result<Vec<SuggestionKind>, String> {
+    input.split(',').map(|s| s.trim().parse()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggestion_kind_display_roundtrip() {
+        for kind in SuggestionKind::ALL {
+            let s = kind.to_string();
+            let parsed: SuggestionKind = s.parse().unwrap();
+            assert_eq!(*kind, parsed);
+        }
+    }
+
+    #[test]
+    fn suggestion_kind_from_str_unknown() {
+        assert!("unknown".parse::<SuggestionKind>().is_err());
+    }
+
+    #[test]
+    fn parse_types_single() {
+        let types = parse_types("star").unwrap();
+        assert_eq!(types, vec![SuggestionKind::Star]);
+    }
+
+    #[test]
+    fn parse_types_multiple() {
+        let types = parse_types("star,issue,donate").unwrap();
+        assert_eq!(
+            types,
+            vec![
+                SuggestionKind::Star,
+                SuggestionKind::Issue,
+                SuggestionKind::Donate,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_types_with_whitespace() {
+        let types = parse_types("star , docs").unwrap();
+        assert_eq!(types, vec![SuggestionKind::Star, SuggestionKind::Docs]);
+    }
+
+    #[test]
+    fn parse_types_invalid() {
+        assert!(parse_types("star,bogus").is_err());
+    }
+
+    #[test]
+    fn suggestion_kind_emoji() {
+        // Just verify each kind has a non-empty emoji.
+        for kind in SuggestionKind::ALL {
+            assert!(!kind.emoji().is_empty());
+        }
+    }
+
+    #[test]
+    fn suggestion_serde_roundtrip() {
+        let suggestion = ContributionSuggestion {
+            kind: SuggestionKind::Star,
+            title: "Star curl/curl on GitHub".to_string(),
+            url: "https://github.com/curl/curl".to_string(),
+        };
+        let json = serde_json::to_string(&suggestion).unwrap();
+        let parsed: ContributionSuggestion = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.kind, SuggestionKind::Star);
+        assert_eq!(parsed.title, "Star curl/curl on GitHub");
+        assert_eq!(parsed.url, "https://github.com/curl/curl");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use syld::config::Config;
+use syld::contribute::suggest::{self, SuggestionKind};
 use syld::discover::{self, InstalledPackage};
 use syld::enrich::EnrichmentMap;
 use syld::hook::{self, HookContext};
@@ -24,7 +25,8 @@ use syld::storage::Storage;
 Workflow:
   1. First time     syld setup
   2. Discover       syld scan
-  3. Review         syld report"
+  3. Review         syld report
+  4. Contribute     syld contribute"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -80,6 +82,17 @@ enum Commands {
     Hook {
         #[command(subcommand)]
         command: HookCommands,
+    },
+
+    /// Suggest actionable ways to support open source projects you depend on
+    Contribute {
+        /// Number of suggestions to show
+        #[arg(short, default_value = "3")]
+        n: usize,
+
+        /// Comma-separated contribution types to include (star, issue, donate, docs, spread)
+        #[arg(long = "type", value_name = "TYPES")]
+        types: Option<String>,
     },
 
     /// Interactive first-time setup wizard
@@ -171,6 +184,7 @@ fn main() -> Result<()> {
         Some(Commands::Cache { command }) => cmd_cache(&command),
         Some(Commands::Config { command }) => cmd_config(&config, &command),
         Some(Commands::Hook { command }) => cmd_hook(&config, &command),
+        Some(Commands::Contribute { n, types }) => cmd_contribute(&config, n, types.as_deref()),
         Some(Commands::Setup) => cmd_setup(&config),
         Some(Commands::Install { command }) => cmd_install(&command),
     }
@@ -325,6 +339,32 @@ fn cmd_report(
         }
     }
 
+    Ok(())
+}
+
+fn cmd_contribute(config: &Config, n: usize, types: Option<&str>) -> Result<()> {
+    let _filter: Vec<SuggestionKind> = match types {
+        Some(input) => suggest::parse_types(input).map_err(|e| anyhow::anyhow!(e))?,
+        None => SuggestionKind::ALL.to_vec(),
+    };
+
+    let storage = Storage::open().context("Failed to open database")?;
+    let scan = storage
+        .latest_scan()
+        .context("Failed to read latest scan")?;
+
+    if scan.is_none() {
+        eprintln!("No scan data found. Run `syld scan` first.");
+        return Ok(());
+    }
+
+    // TODO(#87): Generate suggestions from scan/enrichment data
+    // TODO(#88): Filter completed contributions, randomize, and format output
+
+    let _ = (config, n);
+    eprintln!(
+        "No suggestions available. Run `syld report` with enrichment enabled to populate project data."
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Adds the `contribute` subcommand with `-n` (count) and `--type` (comma-separated filter) flags
- Introduces `SuggestionKind` enum and `ContributionSuggestion` struct in new `contribute::suggest` module
- Wires a stub handler that validates inputs and checks for scan data
- Includes unit tests for type parsing, serde roundtrip, and display/fromstr

Closes #86
Part of #63

## Test plan
- [x] `syld contribute --help` shows correct usage
- [x] `syld contribute` runs with default flags (n=3, all types)
- [x] `syld contribute -n 5 --type star,issue` parses correctly
- [x] `syld contribute --type bogus` produces clear error
- [x] All 298 unit tests + 45 integration tests pass
- [x] Pre-commit hooks pass (clippy + fmt)