### PR TITLE
Add filtering, randomization, and formatted output for contribute command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +301,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -601,6 +621,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1314,7 +1335,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1362,7 +1383,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1372,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1383,6 +1415,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -1762,6 +1800,7 @@ dependencies = [
  "indicatif",
  "jsonschema",
  "predicates",
+ "rand 0.10.0",
  "rayon",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ indicatif = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
 dialoguer = "0.11"
+rand = "0.10.0"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/src/contribute/suggest.rs
+++ b/src/contribute/suggest.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
 
+use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 
 use super::{ContributionRecord, ContributionRecordKind};
@@ -243,6 +244,45 @@ fn generate_spread(project: &UpstreamProject) -> Option<ContributionSuggestion> 
         ),
         url: repo_url.clone(),
     })
+}
+
+/// Randomly shuffle and pick up to `n` suggestions.
+pub fn pick_random(
+    mut suggestions: Vec<ContributionSuggestion>,
+    n: usize,
+) -> Vec<ContributionSuggestion> {
+    let mut rng = rand::rng();
+    suggestions.shuffle(&mut rng);
+    suggestions.truncate(n);
+    suggestions
+}
+
+/// Format suggestions for terminal display.
+///
+/// Produces the numbered list described in the `contribute` command spec:
+///
+/// ```text
+/// Here are 3 ways you can support open source today:
+///
+///   1. ⭐ Star curl/curl on GitHub
+///      https://github.com/curl/curl
+/// ```
+pub fn format_suggestions(suggestions: &[ContributionSuggestion]) -> String {
+    let count = suggestions.len();
+    if count == 0 {
+        return String::new();
+    }
+
+    let noun = if count == 1 { "way" } else { "ways" };
+    let mut out = format!("Here are {count} {noun} you can support open source today:\n");
+
+    for (i, s) in suggestions.iter().enumerate() {
+        let num = i + 1;
+        let emoji = s.kind.emoji();
+        out.push_str(&format!("\n  {num}. {emoji} {}\n     {}\n", s.title, s.url));
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -493,5 +533,100 @@ mod tests {
         assert_eq!(parsed.kind, SuggestionKind::Star);
         assert_eq!(parsed.title, "Star curl/curl on GitHub");
         assert_eq!(parsed.url, "https://github.com/curl/curl");
+    }
+
+    // -- pick_random tests --
+
+    fn make_suggestion(kind: SuggestionKind, name: &str) -> ContributionSuggestion {
+        ContributionSuggestion {
+            kind,
+            title: format!("Action for {name}"),
+            url: format!("https://example.com/{name}"),
+        }
+    }
+
+    #[test]
+    fn pick_random_limits_to_n() {
+        let suggestions = vec![
+            make_suggestion(SuggestionKind::Star, "a"),
+            make_suggestion(SuggestionKind::Issue, "b"),
+            make_suggestion(SuggestionKind::Donate, "c"),
+            make_suggestion(SuggestionKind::Docs, "d"),
+        ];
+        let picked = pick_random(suggestions, 2);
+        assert_eq!(picked.len(), 2);
+    }
+
+    #[test]
+    fn pick_random_returns_all_when_fewer_than_n() {
+        let suggestions = vec![make_suggestion(SuggestionKind::Star, "a")];
+        let picked = pick_random(suggestions, 5);
+        assert_eq!(picked.len(), 1);
+    }
+
+    #[test]
+    fn pick_random_empty_input() {
+        let picked = pick_random(vec![], 3);
+        assert!(picked.is_empty());
+    }
+
+    // -- format_suggestions tests --
+
+    #[test]
+    fn format_suggestions_empty() {
+        assert_eq!(format_suggestions(&[]), String::new());
+    }
+
+    #[test]
+    fn format_suggestions_single() {
+        let suggestions = vec![ContributionSuggestion {
+            kind: SuggestionKind::Star,
+            title: "Star curl/curl on GitHub".to_string(),
+            url: "https://github.com/curl/curl".to_string(),
+        }];
+        let output = format_suggestions(&suggestions);
+        assert!(output.starts_with("Here are 1 way you can support open source today:"));
+        assert!(output.contains("1. ⭐ Star curl/curl on GitHub"));
+        assert!(output.contains("https://github.com/curl/curl"));
+    }
+
+    #[test]
+    fn format_suggestions_multiple() {
+        let suggestions = vec![
+            ContributionSuggestion {
+                kind: SuggestionKind::Star,
+                title: "Star curl/curl on GitHub".to_string(),
+                url: "https://github.com/curl/curl".to_string(),
+            },
+            ContributionSuggestion {
+                kind: SuggestionKind::Donate,
+                title: "Donate to curl via Open Collective".to_string(),
+                url: "https://opencollective.com/curl".to_string(),
+            },
+            ContributionSuggestion {
+                kind: SuggestionKind::Issue,
+                title: "Check good first issues on systemd/systemd".to_string(),
+                url: "https://github.com/systemd/systemd/issues?q=label:\"good first issue\""
+                    .to_string(),
+            },
+        ];
+        let output = format_suggestions(&suggestions);
+        assert!(output.starts_with("Here are 3 ways you can support open source today:"));
+        assert!(output.contains("1. ⭐"));
+        assert!(output.contains("2. 💰"));
+        assert!(output.contains("3. 🐛"));
+    }
+
+    #[test]
+    fn format_suggestions_numbering_and_indentation() {
+        let suggestions = vec![
+            make_suggestion(SuggestionKind::Star, "a"),
+            make_suggestion(SuggestionKind::Issue, "b"),
+        ];
+        let output = format_suggestions(&suggestions);
+        // Check indentation: numbers at 2 spaces, URLs at 5 spaces
+        assert!(output.contains("  1."));
+        assert!(output.contains("  2."));
+        assert!(output.contains("     https://"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,9 +378,10 @@ fn cmd_contribute(config: &Config, n: usize, types: Option<&str>) -> Result<()> 
         return Ok(());
     }
 
-    // TODO(#88): Randomize, limit to n, and format output
+    let selected = suggest::pick_random(suggestions, n);
+    print!("{}", suggest::format_suggestions(&selected));
 
-    let _ = (config, n);
+    let _ = config;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes #88

- Add `pick_random()` to shuffle and limit suggestions to the requested count (`-n` flag)
- Add `format_suggestions()` to produce numbered, emoji-prefixed terminal output matching the spec from #63
- Wire both into `cmd_contribute` replacing the TODO placeholder
- Handle edge cases: empty suggestions, fewer suggestions than requested, singular/plural "way(s)"
- Add `rand` dependency for shuffling

## Example output

```
Here are 3 ways you can support open source today:

  1. ⭐ Star mass-driver/pytest-docker-tools on GitHub
     https://github.com/mass-driver/pytest-docker-tools

  2. 🐛 Check good first issues on systemd/systemd
     https://github.com/systemd/systemd/issues?q=label:"good first issue"

  3. 💰 Donate to curl via Open Collective
     https://opencollective.com/curl
```

## Test plan

- [x] Unit tests for `pick_random` (limits to n, handles fewer than n, handles empty)
- [x] Unit tests for `format_suggestions` (empty, single, multiple, numbering/indentation)
- [x] All 323 existing tests still pass
- [x] `cargo fmt` and `cargo clippy` clean