### PR TITLE
Add Rust compilation caching to CI workflow (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      - uses: Swatinem/rust-cache@v2
       - run: mise run check


### PR DESCRIPTION
## Summary
- Add `Swatinem/rust-cache@v2` step to the CI workflow between tool installation and the check task
- This caches `~/.cargo` and `target/` directories across CI runs, avoiding full Rust rebuilds on cache hits

## Test plan
- [ ] Verify the CI workflow runs successfully on this PR
- [ ] Confirm subsequent runs are faster due to cache hits

Closes #99