### PR TITLE
Improve CI cache key and add status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: v0-linux-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - run: mise run check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # syld — Support Your Linux Desktop
 
+[![CI](https://github.com/bombfork/syld/actions/workflows/ci.yml/badge.svg)](https://github.com/bombfork/syld/actions/workflows/ci.yml)
+
 <div align="center">
 
 <img src="https://imgs.xkcd.com/comics/dependency.png" alt="xkcd 2347: Dependency — All modern digital infrastructure held up by a project some random person in Nebraska has been mass maintaining since 2003" width="400">


### PR DESCRIPTION
## Summary
- Add CI status badge to the top of the README
- Replace `Swatinem/rust-cache` with `actions/cache`, using `Cargo.lock` hash as the sole cache key — the only thing that determines whether a Rust build cache is valid

## Test plan
- [ ] Verify CI runs and caching works on this PR
- [ ] Check the badge renders correctly on the repo page