### PR TITLE
Hooks invoke contribute suggestion engine instead of custom output

### DIFF
--- a/src/contribute/suggest.rs
+++ b/src/contribute/suggest.rs
@@ -285,6 +285,38 @@ pub fn format_suggestions(suggestions: &[ContributionSuggestion]) -> String {
     out
 }
 
+/// Format suggestions for hook output (stderr, brief, non-intrusive).
+///
+/// Produces a compact list suitable for display after package manager
+/// transactions:
+///
+/// ```text
+/// syld: 3 ways to support the packages you just installed:
+///
+///   1. ⭐ Star curl/curl on GitHub
+///      https://github.com/curl/curl
+///
+/// Run `syld contribute` for more suggestions.
+/// ```
+pub fn format_hook_suggestions(suggestions: &[ContributionSuggestion]) -> String {
+    let count = suggestions.len();
+    if count == 0 {
+        return String::new();
+    }
+
+    let noun = if count == 1 { "way" } else { "ways" };
+    let mut out = format!("\nsyld: {count} {noun} to support the packages you just installed:\n");
+
+    for (i, s) in suggestions.iter().enumerate() {
+        let num = i + 1;
+        let emoji = s.kind.emoji();
+        out.push_str(&format!("\n  {num}. {emoji} {}\n     {}\n", s.title, s.url));
+    }
+
+    out.push_str("\nRun `syld contribute` for more suggestions.\n");
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,5 +660,38 @@ mod tests {
         assert!(output.contains("  1."));
         assert!(output.contains("  2."));
         assert!(output.contains("     https://"));
+    }
+
+    // -- format_hook_suggestions tests --
+
+    #[test]
+    fn format_hook_suggestions_empty() {
+        assert_eq!(format_hook_suggestions(&[]), String::new());
+    }
+
+    #[test]
+    fn format_hook_suggestions_has_hook_header_and_footer() {
+        let suggestions = vec![ContributionSuggestion {
+            kind: SuggestionKind::Star,
+            title: "Star curl/curl on GitHub".to_string(),
+            url: "https://github.com/curl/curl".to_string(),
+        }];
+        let output = format_hook_suggestions(&suggestions);
+        assert!(output.contains("syld: 1 way to support the packages you just installed:"));
+        assert!(output.contains("Run `syld contribute` for more suggestions."));
+    }
+
+    #[test]
+    fn format_hook_suggestions_multiple() {
+        let suggestions = vec![
+            make_suggestion(SuggestionKind::Star, "a"),
+            make_suggestion(SuggestionKind::Donate, "b"),
+            make_suggestion(SuggestionKind::Issue, "c"),
+        ];
+        let output = format_hook_suggestions(&suggestions);
+        assert!(output.contains("3 ways to support"));
+        assert!(output.contains("1. ⭐"));
+        assert!(output.contains("2. 💰"));
+        assert!(output.contains("3. 🐛"));
     }
 }

--- a/src/hook/pacman_post_transaction.rs
+++ b/src/hook/pacman_post_transaction.rs
@@ -3,25 +3,32 @@
 //! Pacman post-transaction hook.
 //!
 //! Surfaces contribution opportunities after pacman installs or upgrades
-//! packages. Reads existing scan and enrichment data from the local SQLite
-//! cache — no network calls, so it's fast enough for inline pacman output.
+//! packages. Uses the contribution suggestion engine to generate actionable
+//! suggestions scoped to the packages in the transaction. Reads existing
+//! scan and project data from the local SQLite cache — no network calls,
+//! so it's fast enough for inline pacman output.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::Result;
 
 use super::{Hook, HookContext};
+use crate::contribute::suggest::{self, SuggestionKind};
 use crate::report::terminal::normalize_url;
 use crate::storage::Storage;
 
 const PACMAN_DB_PATH: &str = "/var/lib/pacman/local";
 
+/// Maximum number of suggestions to show in hook output.
+const MAX_HOOK_SUGGESTIONS: usize = 3;
+
 /// Post-transaction hook for pacman (Arch Linux).
 ///
-/// After pacman installs or upgrades packages, this hook checks the local
-/// enrichment cache for funding links and prints a brief summary to stderr.
-/// It never makes network calls and returns `Ok(())` silently when there is
-/// no data to show.
+/// After pacman installs or upgrades packages, this hook uses the
+/// contribution suggestion engine to show a brief list of ways the user
+/// can support the affected projects. It never makes network calls and
+/// returns `Ok(())` silently when there is no data to show.
 pub struct PacmanPostTransactionHook;
 
 impl Hook for PacmanPostTransactionHook {
@@ -30,7 +37,7 @@ impl Hook for PacmanPostTransactionHook {
     }
 
     fn description(&self) -> &str {
-        "Show funding opportunities after pacman transactions"
+        "Show contribution suggestions after pacman transactions"
     }
 
     fn is_available(&self) -> bool {
@@ -53,12 +60,13 @@ impl Hook for PacmanPostTransactionHook {
         };
 
         // Match targets against scanned packages to find their URLs
-        let mut matched_urls: Vec<(String, String)> = Vec::new();
+        let mut matched_urls: HashSet<String> = HashSet::new();
         for target in &ctx.targets {
             for pkg in &scan.packages {
                 if pkg.name == *target {
                     if let Some(url) = &pkg.url {
-                        matched_urls.push((pkg.name.clone(), url.clone()));
+                        matched_urls.insert(url.clone());
+                        matched_urls.insert(normalize_url(url));
                     }
                     break;
                 }
@@ -69,42 +77,36 @@ impl Hook for PacmanPostTransactionHook {
             return Ok(());
         }
 
-        // Look up enrichment cache for funding links
-        let mut fundable: Vec<(String, Vec<String>)> = Vec::new();
-        for (name, url) in &matched_urls {
-            // Try both the raw URL and the normalized form as cache keys
-            let cached = storage.get_enrichment(url).ok().flatten().or_else(|| {
-                let normalized = normalize_url(url);
-                storage.get_enrichment(&normalized).ok().flatten()
-            });
+        // Load projects and filter to those matching the transaction packages
+        let all_projects = storage.all_projects().unwrap_or_default();
+        let scoped_projects: Vec<_> = all_projects
+            .into_iter()
+            .filter(|p| {
+                let urls: Vec<&str> = [p.repo_url.as_deref(), p.homepage.as_deref()]
+                    .into_iter()
+                    .flatten()
+                    .collect();
+                urls.iter()
+                    .any(|u| matched_urls.contains(*u) || matched_urls.contains(&normalize_url(u)))
+            })
+            .collect();
 
-            if let Some(project) = cached
-                && !project.funding.is_empty()
-            {
-                let links: Vec<String> = project.funding.iter().map(|f| f.url.clone()).collect();
-                fundable.push((name.clone(), links));
-            }
-        }
-
-        if fundable.is_empty() {
+        if scoped_projects.is_empty() {
             return Ok(());
         }
 
-        // Print a brief summary (max 3 projects) to stderr
-        let show_count = fundable.len().min(3);
-        eprintln!();
-        eprintln!("  Some of these packages accept donations:");
-        for (name, links) in fundable.iter().take(show_count) {
-            let link = &links[0];
-            eprintln!("    {name}: {link}");
+        // Generate suggestions using the contribute engine, excluding
+        // contributions the user has already completed
+        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let suggestions =
+            suggest::generate_suggestions(&scoped_projects, &contributions, SuggestionKind::ALL);
+
+        if suggestions.is_empty() {
+            return Ok(());
         }
-        if fundable.len() > 3 {
-            eprintln!(
-                "    ...and {} more (run `syld report --enrich` to see all)",
-                fundable.len() - 3
-            );
-        }
-        eprintln!();
+
+        let selected = suggest::pick_random(suggestions, MAX_HOOK_SUGGESTIONS);
+        eprint!("{}", suggest::format_hook_suggestions(&selected));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes #65

- Replaced the pacman post-transaction hook's custom enrichment-cache-based funding display with the contribution suggestion engine (`suggest::generate_suggestions` + `suggest::pick_random`)
- Suggestions are now scoped to packages in the transaction by matching package URLs against the `projects` table
- Hook output covers all contribution types (star, issue, donate, docs, spread) instead of only funding links
- Added `format_hook_suggestions()` to the suggest module for hook-specific formatting with contextual header/footer
- Limited to 3 suggestions max, silent when none available

### Before
```
  Some of these packages accept donations:
    curl: https://opencollective.com/curl
    systemd: https://github.com/sponsors/systemd
```

### After
```
syld: 3 ways to support the packages you just installed:

  1. ⭐ Star curl/curl on GitHub
     https://github.com/curl/curl

  2. 🐛 Check good first issues on systemd/systemd
     https://github.com/systemd/systemd/issues?q=label:"good first issue"

  3. 💰 Donate to curl via Open Collective
     https://opencollective.com/curl

Run `syld contribute` for more suggestions.
```

## Test plan

- [x] All 326 unit tests pass
- [x] All 58 integration tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] New tests for `format_hook_suggestions` (empty, single, multiple)
- [x] Existing hook tests still pass (empty targets, name/description)