### PR TITLE
fix: generate annotated git tag message from commit log during release

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -131,7 +131,13 @@ git checkout main
 git pull origin main
 
 # --- Tag and push ---
-git tag "v${new_version}"
+prev_tag=$(git tag --sort=-v:refname | head -n1)
+if [[ -n "$prev_tag" ]]; then
+  tag_message=$(git log "${prev_tag}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+else
+  tag_message=$(git log --pretty=format:"- %s (%h)" --no-merges)
+fi
+git tag -a "v${new_version}" -m "$tag_message"
 git push origin "v${new_version}"
 
 # --- Cleanup local branch ---


### PR DESCRIPTION
## Summary
- The release task was creating a lightweight tag (`git tag "v..."`) with no message
- Now generates an annotated tag whose message is the commit log since the previous tag, keeping the release fully automated with no human input required for the tag message

## Test plan
- [ ] Run `mise run release --patch` and verify the created tag has an annotated message with the commit log