### PR TITLE
Validate --frequency parameter in install service

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ enum InstallCommands {
     /// Install systemd user service and timer for periodic scans
     Service {
         /// Timer frequency (daily, weekly, monthly)
-        #[arg(long, default_value = "weekly")]
+        #[arg(long, default_value = "weekly", value_parser = ["daily", "weekly", "monthly"])]
         frequency: String,
 
         /// Enable and start the timer immediately

--- a/tests/install_cli.rs
+++ b/tests/install_cli.rs
@@ -86,6 +86,17 @@ fn install_service_writes_files_with_correct_content() {
 }
 
 #[test]
+fn install_service_rejects_invalid_frequency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["install", "service", "--frequency", "invalid"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid"));
+}
+
+#[test]
 fn install_hook_unknown_name_fails() {
     let tmp = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Adds `value_parser = ["daily", "weekly", "monthly"]` to the `--frequency` clap argument, so invalid values are rejected at parse time with a clear error listing valid options
- Adds a CLI test verifying that invalid frequency values are rejected

Closes #111