### PR TITLE
Fix pacman hook finding no data when running as root

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -54,6 +54,8 @@
 
 pub mod pacman_post_transaction;
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 
 use crate::config::Config;
@@ -65,6 +67,14 @@ pub struct HookContext<'a> {
 
     /// Package names provided via stdin (one per line).
     pub targets: Vec<String>,
+
+    /// Optional override for the database path.
+    ///
+    /// When set, hooks should use this path instead of the default
+    /// `Storage::open()` resolution. This is needed when hooks run as root
+    /// (e.g. pacman ALPM hooks), where `$HOME` resolves to `/root` instead
+    /// of the installing user's home directory.
+    pub db_path: Option<PathBuf>,
 }
 
 /// Trait for package manager hook backends.

--- a/src/hook/pacman_post_transaction.rs
+++ b/src/hook/pacman_post_transaction.rs
@@ -46,9 +46,15 @@ impl Hook for PacmanPostTransactionHook {
             return Ok(());
         }
 
-        let storage = match Storage::open() {
-            Ok(s) => s,
-            Err(_) => return Ok(()), // No database yet — nothing to report
+        let storage = match ctx.db_path {
+            Some(ref path) => match Storage::open_path(path) {
+                Ok(s) => s,
+                Err(_) => return Ok(()),
+            },
+            None => match Storage::open() {
+                Ok(s) => s,
+                Err(_) => return Ok(()), // No database yet — nothing to report
+            },
         };
 
         // Load all enriched projects from the database.
@@ -92,6 +98,7 @@ mod tests {
         let ctx = HookContext {
             config: &config,
             targets: vec![],
+            db_path: None,
         };
         // Should return Ok silently
         assert!(hook.run(&ctx).is_ok());
@@ -105,6 +112,7 @@ mod tests {
         let ctx = HookContext {
             config: &config,
             targets: vec!["curl".to_string()],
+            db_path: None,
         };
         assert!(hook.run(&ctx).is_ok());
     }

--- a/src/install/hook_install.rs
+++ b/src/install/hook_install.rs
@@ -4,7 +4,9 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+
+use crate::config::Config;
 
 use super::{remove_with_elevated, resolve_binary_path, write_with_elevated};
 
@@ -21,7 +23,10 @@ pub struct InstallableHook {
 }
 
 /// Generate the contents of a pacman ALPM hook file.
-pub fn generate_pacman_hook(binary_path: &Path) -> String {
+///
+/// `db_path` is baked into the `Exec` line so the hook works correctly
+/// even when pacman runs as root (where `$HOME` would resolve to `/root`).
+pub fn generate_pacman_hook(binary_path: &Path, db_path: &Path) -> String {
     format!(
         "\
 [Trigger]
@@ -33,10 +38,11 @@ Target = *
 [Action]
 Description = Displaying open source contribution opportunities...
 When = PostTransaction
-Exec = {} hook run pacman-post-transaction
+Exec = {} hook run pacman-post-transaction --db-path {}
 NeedsTargets
 ",
-        binary_path.display()
+        binary_path.display(),
+        db_path.display()
     )
 }
 
@@ -47,7 +53,9 @@ NeedsTargets
 /// Removes the old `syld.hook` if present to avoid running twice.
 pub fn install_pacman_hook() -> Result<()> {
     let binary = resolve_binary_path()?;
-    let content = generate_pacman_hook(&binary);
+    let data_dir = Config::data_dir().context("Failed to resolve data directory for hook")?;
+    let db_path = data_dir.join("syld.db");
+    let content = generate_pacman_hook(&binary, &db_path);
 
     // Remove the old hook path if it exists (renamed to 99-syld.hook)
     let old_path = PathBuf::from("/usr/share/libalpm/hooks/syld.hook");
@@ -75,12 +83,13 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn generate_pacman_hook_interpolates_binary_path() {
-        let path = PathBuf::from("/home/user/.cargo/bin/syld");
-        let content = generate_pacman_hook(&path);
-        assert!(
-            content.contains("Exec = /home/user/.cargo/bin/syld hook run pacman-post-transaction")
-        );
+    fn generate_pacman_hook_interpolates_binary_and_db_path() {
+        let binary = PathBuf::from("/home/user/.cargo/bin/syld");
+        let db = PathBuf::from("/home/user/.local/share/syld/syld.db");
+        let content = generate_pacman_hook(&binary, &db);
+        assert!(content.contains(
+            "Exec = /home/user/.cargo/bin/syld hook run pacman-post-transaction --db-path /home/user/.local/share/syld/syld.db"
+        ));
         assert!(content.contains("NeedsTargets"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{Context, Result};
@@ -132,6 +133,10 @@ enum HookCommands {
     Run {
         /// Hook name (e.g. pacman-post-transaction)
         name: String,
+
+        /// Path to the syld database (overrides default resolution)
+        #[arg(long)]
+        db_path: Option<PathBuf>,
     },
 
     /// List all hooks with their availability status
@@ -984,12 +989,12 @@ fn cmd_cache(command: &CacheCommands) -> Result<()> {
 
 fn cmd_hook(config: &Config, command: &HookCommands) -> Result<()> {
     match command {
-        HookCommands::Run { name } => cmd_hook_run(config, name),
+        HookCommands::Run { name, db_path } => cmd_hook_run(config, name, db_path.as_deref()),
         HookCommands::List => cmd_hook_list(),
     }
 }
 
-fn cmd_hook_run(config: &Config, name: &str) -> Result<()> {
+fn cmd_hook_run(config: &Config, name: &str, db_path: Option<&std::path::Path>) -> Result<()> {
     let hook = match hook::find_hook(name) {
         Some(h) => h,
         None => {
@@ -1014,7 +1019,11 @@ fn cmd_hook_run(config: &Config, name: &str) -> Result<()> {
         })
         .collect();
 
-    let ctx = HookContext { config, targets };
+    let ctx = HookContext {
+        config,
+        targets,
+        db_path: db_path.map(|p| p.to_path_buf()),
+    };
 
     hook.run(&ctx)
 }


### PR DESCRIPTION
## Summary

- When the pacman ALPM hook runs as root, `$HOME` resolves to `/root`, so `Storage::open()` looks for the database at `/root/.local/share/syld/syld.db` instead of the installing user's path — finding nothing and silently returning with no suggestions
- Bake the database path into the hook's `Exec` line at install time via `--db-path`, so the hook always reads the correct database regardless of the executing user
- Users need to re-run `syld install hook` after upgrading to pick up the new hook file

## Changes

- **`src/main.rs`** — Add `--db-path <PATH>` option to `syld hook run`
- **`src/hook/mod.rs`** — Add `db_path: Option<PathBuf>` to `HookContext`
- **`src/hook/pacman_post_transaction.rs`** — Use `Storage::open_path()` when `db_path` is provided
- **`src/install/hook_install.rs`** — Resolve the user's db path at install time and emit it in the `Exec` line

## Test plan

- [x] `cargo test` — all 337 tests pass
- [x] Run `syld install hook` and inspect `/usr/share/libalpm/hooks/99-syld.hook` to confirm `--db-path` is present with the correct user path
- [x] Install a package with pacman and verify suggestions appear