### PR TITLE
Add APT hook, same as pacman hook

### DIFF
--- a/src/hook/apt_post_invoke.rs
+++ b/src/hook/apt_post_invoke.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! APT post-invoke hook.
+//!
+//! Surfaces contribution opportunities after APT installs or upgrades
+//! packages. Uses the contribution suggestion engine to generate actionable
+//! suggestions from all enriched project data. No network calls, so it's
+//! fast enough for inline APT output.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::{Hook, HookContext};
+use crate::contribute::suggest::{self, SuggestionKind};
+use crate::storage::Storage;
+
+const DPKG_STATUS_PATH: &str = "/var/lib/dpkg/status";
+
+/// Maximum number of suggestions to show in hook output.
+const MAX_HOOK_SUGGESTIONS: usize = 3;
+
+/// Post-invoke hook for APT (Debian/Ubuntu).
+///
+/// After APT installs or upgrades packages, this hook uses the
+/// contribution suggestion engine to show a brief list of ways the user
+/// can support the affected projects. It never makes network calls and
+/// returns `Ok(())` silently when there is no data to show.
+pub struct AptPostInvokeHook;
+
+impl Hook for AptPostInvokeHook {
+    fn name(&self) -> &str {
+        "apt-post-invoke"
+    }
+
+    fn description(&self) -> &str {
+        "Show contribution suggestions after APT transactions"
+    }
+
+    fn is_available(&self) -> bool {
+        Path::new(DPKG_STATUS_PATH).is_file()
+    }
+
+    fn run(&self, ctx: &HookContext) -> Result<()> {
+        if ctx.targets.is_empty() {
+            return Ok(());
+        }
+
+        let storage = match ctx.db_path {
+            Some(ref path) => match Storage::open_path(path) {
+                Ok(s) => s,
+                Err(_) => return Ok(()),
+            },
+            None => match Storage::open() {
+                Ok(s) => s,
+                Err(_) => return Ok(()), // No database yet — nothing to report
+            },
+        };
+
+        // Load all enriched projects from the database.
+        let projects = storage.all_projects().unwrap_or_default();
+        if projects.is_empty() {
+            return Ok(());
+        }
+
+        // Generate suggestions using the contribute engine, excluding
+        // contributions the user has already completed.
+        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let suggestions =
+            suggest::generate_suggestions(&projects, &contributions, SuggestionKind::ALL);
+
+        if suggestions.is_empty() {
+            return Ok(());
+        }
+
+        let selected = suggest::pick_random(suggestions, MAX_HOOK_SUGGESTIONS);
+        eprint!("{}", suggest::format_hook_suggestions(&selected));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_and_description() {
+        let hook = AptPostInvokeHook;
+        assert_eq!(hook.name(), "apt-post-invoke");
+        assert!(!hook.description().is_empty());
+    }
+
+    #[test]
+    fn run_with_empty_targets_succeeds() {
+        let hook = AptPostInvokeHook;
+        let config = crate::config::Config::default();
+        let ctx = HookContext {
+            config: &config,
+            targets: vec![],
+            db_path: None,
+        };
+        // Should return Ok silently
+        assert!(hook.run(&ctx).is_ok());
+    }
+
+    #[test]
+    fn run_with_targets_no_db_succeeds() {
+        // When there's no database, the hook should return Ok silently
+        let hook = AptPostInvokeHook;
+        let config = crate::config::Config::default();
+        let ctx = HookContext {
+            config: &config,
+            targets: vec!["curl".to_string()],
+            db_path: None,
+        };
+        assert!(hook.run(&ctx).is_ok());
+    }
+}

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -52,6 +52,7 @@
 //! vector. The new hook will be included automatically whenever its
 //! [`is_available()`](Hook::is_available) check passes.
 
+pub mod apt_post_invoke;
 pub mod pacman_post_transaction;
 
 use std::path::PathBuf;
@@ -115,7 +116,10 @@ pub trait Hook {
 /// Used by `syld hook list` to show all hooks with their status, and by
 /// `find_hook()` to look up a hook by name.
 pub fn all_hooks() -> Vec<Box<dyn Hook>> {
-    vec![Box::new(pacman_post_transaction::PacmanPostTransactionHook)]
+    vec![
+        Box::new(apt_post_invoke::AptPostInvokeHook),
+        Box::new(pacman_post_transaction::PacmanPostTransactionHook),
+    ]
 }
 
 /// Returns all hooks that are available in the current environment.
@@ -189,6 +193,12 @@ mod tests {
     fn all_hooks_contains_pacman() {
         let hooks = all_hooks();
         assert!(hooks.iter().any(|h| h.name() == "pacman-post-transaction"));
+    }
+
+    #[test]
+    fn all_hooks_contains_apt() {
+        let hooks = all_hooks();
+        assert!(hooks.iter().any(|h| h.name() == "apt-post-invoke"));
     }
 
     #[test]

--- a/src/install/hook_install.rs
+++ b/src/install/hook_install.rs
@@ -46,6 +46,19 @@ NeedsTargets
     )
 }
 
+/// Generate the contents of an APT post-invoke configuration file.
+///
+/// `db_path` is baked into the command so the hook works correctly
+/// even when APT runs as root (where `$HOME` would resolve to `/root`).
+/// The `|| true` suffix ensures hook errors never break APT operations.
+pub fn generate_apt_hook(binary_path: &Path, db_path: &Path) -> String {
+    format!(
+        "DPkg::Post-Invoke {{\"{} hook run apt-post-invoke --db-path {} || true\";}};",
+        binary_path.display(),
+        db_path.display()
+    )
+}
+
 /// Install the pacman post-transaction hook.
 ///
 /// Installs as `99-syld.hook` so it runs after all other ALPM hooks,
@@ -67,14 +80,37 @@ pub fn install_pacman_hook() -> Result<()> {
     write_with_elevated(&path, &content)
 }
 
+/// Install the APT post-invoke hook.
+///
+/// Installs as `99-syld` in `/etc/apt/apt.conf.d/` so it runs after APT
+/// finishes installing or upgrading packages. The `|| true` in the command
+/// ensures hook errors never break APT operations.
+pub fn install_apt_hook() -> Result<()> {
+    let binary = resolve_binary_path()?;
+    let data_dir = Config::data_dir().context("Failed to resolve data directory for hook")?;
+    let db_path = data_dir.join("syld.db");
+    let content = generate_apt_hook(&binary, &db_path);
+
+    let path = PathBuf::from("/etc/apt/apt.conf.d/99-syld");
+    write_with_elevated(&path, &content)
+}
+
 /// Return the registry of hooks that can be installed.
 pub fn installable_hooks() -> Vec<InstallableHook> {
-    vec![InstallableHook {
-        name: "pacman-post-transaction",
-        description: "Run syld after pacman installs/upgrades",
-        available: Path::new("/var/lib/pacman/local").is_dir(),
-        install_fn: install_pacman_hook,
-    }]
+    vec![
+        InstallableHook {
+            name: "apt-post-invoke",
+            description: "Run syld after APT installs/upgrades",
+            available: Path::new("/var/lib/dpkg/status").is_file(),
+            install_fn: install_apt_hook,
+        },
+        InstallableHook {
+            name: "pacman-post-transaction",
+            description: "Run syld after pacman installs/upgrades",
+            available: Path::new("/var/lib/pacman/local").is_dir(),
+            install_fn: install_pacman_hook,
+        },
+    ]
 }
 
 #[cfg(test)]
@@ -94,9 +130,21 @@ mod tests {
     }
 
     #[test]
-    fn installable_hooks_contains_pacman() {
+    fn generate_apt_hook_interpolates_binary_and_db_path() {
+        let binary = PathBuf::from("/home/user/.cargo/bin/syld");
+        let db = PathBuf::from("/home/user/.local/share/syld/syld.db");
+        let content = generate_apt_hook(&binary, &db);
+        assert!(content.contains(
+            "/home/user/.cargo/bin/syld hook run apt-post-invoke --db-path /home/user/.local/share/syld/syld.db"
+        ));
+        assert!(content.contains("|| true"));
+    }
+
+    #[test]
+    fn installable_hooks_contains_pacman_and_apt() {
         let hooks = installable_hooks();
-        assert_eq!(hooks.len(), 1);
-        assert_eq!(hooks[0].name, "pacman-post-transaction");
+        assert_eq!(hooks.len(), 2);
+        assert!(hooks.iter().any(|h| h.name == "apt-post-invoke"));
+        assert!(hooks.iter().any(|h| h.name == "pacman-post-transaction"));
     }
 }

--- a/tests/hook_cli.rs
+++ b/tests/hook_cli.rs
@@ -54,6 +54,34 @@ fn hook_run_pacman_empty_stdin_succeeds() {
 }
 
 #[test]
+fn hook_list_succeeds_and_shows_apt() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["hook", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apt-post-invoke"));
+}
+
+#[test]
+fn hook_run_apt_empty_stdin_succeeds() {
+    // Skip on non-Debian systems where dpkg is not available
+    if !Path::new("/var/lib/dpkg/status").is_file() {
+        eprintln!("Skipping: dpkg not available on this system");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["hook", "run", "apt-post-invoke"])
+        .write_stdin("")
+        .assert()
+        .success();
+}
+
+#[test]
 fn hook_list_shows_availability_status() {
     let tmp = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Adds an `apt-post-invoke` hook that shows contribution suggestions after APT installs/upgrades, mirroring the existing `pacman-post-transaction` hook
- Generates an APT conf file (`/etc/apt/apt.conf.d/99-syld`) using `DPkg::Post-Invoke` with `|| true` to prevent hook errors from breaking APT
- Installable via `syld install hook apt-post-invoke` or the interactive `syld install hook` selector

## Test plan
- [x] All existing unit and integration tests pass (327 tests)
- [x] New unit tests: `name_and_description`, `run_with_empty_targets_succeeds`, `run_with_targets_no_db_succeeds`
- [x] New integration tests: `hook_list_succeeds_and_shows_apt`, `hook_run_apt_empty_stdin_succeeds`
- [x] `generate_apt_hook` test verifies correct binary/db path interpolation and `|| true` suffix
- [x] Pre-commit hooks (clippy + fmt) pass
- [ ] Manual test on a Debian/Ubuntu system: `syld install hook apt-post-invoke` then `sudo apt install <package>`

Closes #138