### PR TITLE
Add DNF hook, same as pacman hook

### DIFF
--- a/src/hook/dnf_post_transaction.rs
+++ b/src/hook/dnf_post_transaction.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! DNF post-transaction hook.
+//!
+//! Surfaces contribution opportunities after DNF installs or upgrades
+//! packages. Uses the contribution suggestion engine to generate actionable
+//! suggestions from all enriched project data. No network calls, so it's
+//! fast enough for inline DNF output.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::{Hook, HookContext};
+use crate::contribute::suggest::{self, SuggestionKind};
+use crate::storage::Storage;
+
+const DNF_DATA_PATH: &str = "/var/lib/dnf";
+
+/// Maximum number of suggestions to show in hook output.
+const MAX_HOOK_SUGGESTIONS: usize = 3;
+
+/// Post-transaction hook for DNF (Fedora/RHEL).
+///
+/// After DNF installs or upgrades packages, this hook uses the
+/// contribution suggestion engine to show a brief list of ways the user
+/// can support the affected projects. It never makes network calls and
+/// returns `Ok(())` silently when there is no data to show.
+pub struct DnfPostTransactionHook;
+
+impl Hook for DnfPostTransactionHook {
+    fn name(&self) -> &str {
+        "dnf-post-transaction"
+    }
+
+    fn description(&self) -> &str {
+        "Show contribution suggestions after DNF transactions"
+    }
+
+    fn is_available(&self) -> bool {
+        Path::new(DNF_DATA_PATH).is_dir()
+    }
+
+    fn run(&self, ctx: &HookContext) -> Result<()> {
+        if ctx.targets.is_empty() {
+            return Ok(());
+        }
+
+        let storage = match ctx.db_path {
+            Some(ref path) => match Storage::open_path(path) {
+                Ok(s) => s,
+                Err(_) => return Ok(()),
+            },
+            None => match Storage::open() {
+                Ok(s) => s,
+                Err(_) => return Ok(()), // No database yet — nothing to report
+            },
+        };
+
+        // Load all enriched projects from the database.
+        let projects = storage.all_projects().unwrap_or_default();
+        if projects.is_empty() {
+            return Ok(());
+        }
+
+        // Generate suggestions using the contribute engine, excluding
+        // contributions the user has already completed.
+        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let suggestions =
+            suggest::generate_suggestions(&projects, &contributions, SuggestionKind::ALL);
+
+        if suggestions.is_empty() {
+            return Ok(());
+        }
+
+        let selected = suggest::pick_random(suggestions, MAX_HOOK_SUGGESTIONS);
+        eprint!("{}", suggest::format_hook_suggestions(&selected));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_and_description() {
+        let hook = DnfPostTransactionHook;
+        assert_eq!(hook.name(), "dnf-post-transaction");
+        assert!(!hook.description().is_empty());
+    }
+
+    #[test]
+    fn run_with_empty_targets_succeeds() {
+        let hook = DnfPostTransactionHook;
+        let config = crate::config::Config::default();
+        let ctx = HookContext {
+            config: &config,
+            targets: vec![],
+            db_path: None,
+        };
+        // Should return Ok silently
+        assert!(hook.run(&ctx).is_ok());
+    }
+
+    #[test]
+    fn run_with_targets_no_db_succeeds() {
+        // When there's no database, the hook should return Ok silently
+        let hook = DnfPostTransactionHook;
+        let config = crate::config::Config::default();
+        let ctx = HookContext {
+            config: &config,
+            targets: vec!["curl".to_string()],
+            db_path: None,
+        };
+        assert!(hook.run(&ctx).is_ok());
+    }
+}

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -53,6 +53,7 @@
 //! [`is_available()`](Hook::is_available) check passes.
 
 pub mod apt_post_invoke;
+pub mod dnf_post_transaction;
 pub mod pacman_post_transaction;
 
 use std::path::PathBuf;
@@ -118,6 +119,7 @@ pub trait Hook {
 pub fn all_hooks() -> Vec<Box<dyn Hook>> {
     vec![
         Box::new(apt_post_invoke::AptPostInvokeHook),
+        Box::new(dnf_post_transaction::DnfPostTransactionHook),
         Box::new(pacman_post_transaction::PacmanPostTransactionHook),
     ]
 }
@@ -199,6 +201,12 @@ mod tests {
     fn all_hooks_contains_apt() {
         let hooks = all_hooks();
         assert!(hooks.iter().any(|h| h.name() == "apt-post-invoke"));
+    }
+
+    #[test]
+    fn all_hooks_contains_dnf() {
+        let hooks = all_hooks();
+        assert!(hooks.iter().any(|h| h.name() == "dnf-post-transaction"));
     }
 
     #[test]

--- a/src/install/hook_install.rs
+++ b/src/install/hook_install.rs
@@ -95,6 +95,35 @@ pub fn install_apt_hook() -> Result<()> {
     write_with_elevated(&path, &content)
 }
 
+/// Generate the contents of a DNF post-transaction-actions action file.
+///
+/// `db_path` is baked into the command so the hook works correctly
+/// even when DNF runs as root (where `$HOME` would resolve to `/root`).
+/// The `|| true` suffix ensures hook errors never break DNF operations.
+pub fn generate_dnf_hook(binary_path: &Path, db_path: &Path) -> String {
+    format!(
+        "*:any:{} hook run dnf-post-transaction --db-path {} || true",
+        binary_path.display(),
+        db_path.display()
+    )
+}
+
+/// Install the DNF post-transaction hook.
+///
+/// Installs as `syld.action` in `/etc/dnf/plugins/post-transaction-actions.d/`
+/// so it runs after DNF finishes installing or upgrading packages. This uses
+/// the `post-transaction-actions` DNF plugin. The `|| true` in the command
+/// ensures hook errors never break DNF operations.
+pub fn install_dnf_hook() -> Result<()> {
+    let binary = resolve_binary_path()?;
+    let data_dir = Config::data_dir().context("Failed to resolve data directory for hook")?;
+    let db_path = data_dir.join("syld.db");
+    let content = generate_dnf_hook(&binary, &db_path);
+
+    let path = PathBuf::from("/etc/dnf/plugins/post-transaction-actions.d/syld.action");
+    write_with_elevated(&path, &content)
+}
+
 /// Return the registry of hooks that can be installed.
 pub fn installable_hooks() -> Vec<InstallableHook> {
     vec![
@@ -103,6 +132,12 @@ pub fn installable_hooks() -> Vec<InstallableHook> {
             description: "Run syld after APT installs/upgrades",
             available: Path::new("/var/lib/dpkg/status").is_file(),
             install_fn: install_apt_hook,
+        },
+        InstallableHook {
+            name: "dnf-post-transaction",
+            description: "Run syld after DNF installs/upgrades",
+            available: Path::new("/var/lib/dnf").is_dir(),
+            install_fn: install_dnf_hook,
         },
         InstallableHook {
             name: "pacman-post-transaction",
@@ -141,10 +176,22 @@ mod tests {
     }
 
     #[test]
-    fn installable_hooks_contains_pacman_and_apt() {
+    fn generate_dnf_hook_interpolates_binary_and_db_path() {
+        let binary = PathBuf::from("/home/user/.cargo/bin/syld");
+        let db = PathBuf::from("/home/user/.local/share/syld/syld.db");
+        let content = generate_dnf_hook(&binary, &db);
+        assert!(content.contains(
+            "/home/user/.cargo/bin/syld hook run dnf-post-transaction --db-path /home/user/.local/share/syld/syld.db"
+        ));
+        assert!(content.contains("|| true"));
+    }
+
+    #[test]
+    fn installable_hooks_contains_all() {
         let hooks = installable_hooks();
-        assert_eq!(hooks.len(), 2);
+        assert_eq!(hooks.len(), 3);
         assert!(hooks.iter().any(|h| h.name == "apt-post-invoke"));
+        assert!(hooks.iter().any(|h| h.name == "dnf-post-transaction"));
         assert!(hooks.iter().any(|h| h.name == "pacman-post-transaction"));
     }
 }

--- a/tests/hook_cli.rs
+++ b/tests/hook_cli.rs
@@ -82,6 +82,34 @@ fn hook_run_apt_empty_stdin_succeeds() {
 }
 
 #[test]
+fn hook_list_succeeds_and_shows_dnf() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["hook", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dnf-post-transaction"));
+}
+
+#[test]
+fn hook_run_dnf_empty_stdin_succeeds() {
+    // Skip on non-Fedora/RHEL systems where DNF is not available
+    if !Path::new("/var/lib/dnf").is_dir() {
+        eprintln!("Skipping: DNF not available on this system");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    syld_with_db(tmp.path(), data.path())
+        .args(["hook", "run", "dnf-post-transaction"])
+        .write_stdin("")
+        .assert()
+        .success();
+}
+
+#[test]
 fn hook_list_shows_availability_status() {
     let tmp = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Closes #139

- Add `DnfPostTransactionHook` backend (`src/hook/dnf_post_transaction.rs`) following the same pattern as the existing pacman and APT hooks
- Add DNF hook installation support using the `post-transaction-actions` plugin format, writing to `/etc/dnf/plugins/post-transaction-actions.d/syld.action`
- Register the hook in `all_hooks()` and `installable_hooks()`

## Test plan

- [x] All existing tests pass (`cargo test` — 0 failures)
- [x] New unit tests: `name_and_description`, `run_with_empty_targets_succeeds`, `run_with_targets_no_db_succeeds`
- [x] New integration tests: `hook_list_succeeds_and_shows_dnf`, `hook_run_dnf_empty_stdin_succeeds`
- [x] Hook generation test: `generate_dnf_hook_interpolates_binary_and_db_path`
- [x] Pre-commit hooks pass (clippy + fmt)