### PR TITLE
Deduplicate GhIssue struct definition

### DIFF
--- a/src/contribute/github_good_first_issues.rs
+++ b/src/contribute/github_good_first_issues.rs
@@ -19,16 +19,16 @@ pub struct GitHubGoodFirstIssuesBackend;
 
 /// A single issue from the `gh` CLI JSON output.
 #[derive(Debug, Deserialize)]
-struct GhIssue {
-    title: String,
-    url: String,
+pub struct GhIssue {
+    pub title: String,
+    pub url: String,
     #[serde(default)]
-    labels: Vec<GhLabel>,
+    pub labels: Vec<GhLabel>,
 }
 
 #[derive(Debug, Deserialize)]
-struct GhLabel {
-    name: String,
+pub struct GhLabel {
+    pub name: String,
 }
 
 impl ContributionBackend for GitHubGoodFirstIssuesBackend {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 
 use syld::config::Config;
 use syld::contribute::ContributionRecordKind;
-use syld::contribute::github_good_first_issues::extract_github_owner_repo;
+use syld::contribute::github_good_first_issues::{GhIssue, extract_github_owner_repo};
 use syld::contribute::github_sync::is_gh_available;
 use syld::contribute::suggest::{self, SuggestionKind};
 use syld::discover::{self, InstalledPackage};
@@ -603,12 +603,6 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
         if output.status.success() {
             let stdout = String::from_utf8(output.stdout)
                 .context("gh issue list output is not valid UTF-8")?;
-
-            #[derive(serde::Deserialize)]
-            struct GhIssue {
-                title: String,
-                url: String,
-            }
 
             let issues: Vec<GhIssue> =
                 serde_json::from_str(&stdout).context("Failed to parse gh issue list JSON")?;


### PR DESCRIPTION
## Summary
- Made `GhIssue` and `GhLabel` structs public in `contribute::github_good_first_issues`
- Removed the duplicate inline `GhIssue` definition from `main.rs` and imported the shared one
- The superset struct (with `labels` using `#[serde(default)]`) works seamlessly in both call sites

Closes #123