### PR TITLE
Harmonize CLI argument naming for count parameters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ enum Commands {
     /// Discover installed open source packages
     Scan {
         /// Maximum number of projects to display (0 for all)
-        #[arg(long, default_value = "20")]
+        #[arg(short = 'n', long, alias = "count", default_value = "20")]
         limit: usize,
 
         /// Scan only — save results to the database without printing the summary table
@@ -93,8 +93,8 @@ enum Commands {
     #[command(args_conflicts_with_subcommands = true)]
     Contribute {
         /// Number of suggestions to show
-        #[arg(short, default_value = "3")]
-        n: usize,
+        #[arg(short = 'n', long = "limit", alias = "count", default_value = "3")]
+        limit: usize,
 
         /// Comma-separated contribution types to include (star, issue, donate, docs, spread)
         #[arg(long = "type", value_name = "TYPES")]
@@ -228,8 +228,12 @@ fn main() -> Result<()> {
         Some(Commands::Cache { command }) => cmd_cache(&command),
         Some(Commands::Config { command }) => cmd_config(&config, &command),
         Some(Commands::Hook { command }) => cmd_hook(&config, &command),
-        Some(Commands::Contribute { n, types, command }) => match command {
-            None => cmd_contribute(&config, n, types.as_deref()),
+        Some(Commands::Contribute {
+            limit,
+            types,
+            command,
+        }) => match command {
+            None => cmd_contribute(&config, limit, types.as_deref()),
             Some(ContributeCommands::Star { project }) => cmd_contribute_star(project.as_deref()),
             Some(ContributeCommands::Issue { project }) => cmd_contribute_issue(project.as_deref()),
             Some(ContributeCommands::Donate { project }) => {
@@ -394,7 +398,7 @@ fn cmd_report(
     Ok(())
 }
 
-fn cmd_contribute(config: &Config, n: usize, types: Option<&str>) -> Result<()> {
+fn cmd_contribute(config: &Config, limit: usize, types: Option<&str>) -> Result<()> {
     let filter: Vec<SuggestionKind> = match types {
         Some(input) => suggest::parse_types(input).map_err(|e| anyhow::anyhow!(e))?,
         None => SuggestionKind::ALL.to_vec(),
@@ -430,7 +434,7 @@ fn cmd_contribute(config: &Config, n: usize, types: Option<&str>) -> Result<()> 
         return Ok(());
     }
 
-    let selected = suggest::pick_random(suggestions, n);
+    let selected = suggest::pick_random(suggestions, limit);
     print!("{}", suggest::format_suggestions(&selected));
 
     let _ = config;


### PR DESCRIPTION
## Summary

- Unified `-n` / `--limit` (with `--count` alias) across `syld scan` and `syld contribute`
- `scan` gains `-n` short flag; `contribute` gains `--limit` long flag
- Renamed internal field from `n` to `limit` for clarity

Closes #119

## Test plan

- [x] All 410 existing tests pass
- [x] `syld scan --help` shows `-n, --limit`
- [x] `syld contribute --help` shows `-n, --limit`
- [x] `--count` alias works for both commands