### PR TITLE
Use GhRepo::description to enrich upstream projects

### DIFF
--- a/schemas/report.v1.json
+++ b/schemas/report.v1.json
@@ -82,6 +82,10 @@
             "type": "string"
           }
         },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Short project description (e.g. from GitHub), or null if unavailable."
+        },
         "funding": {
           "type": "array",
           "description": "Funding channels for this project. Omitted when empty.",

--- a/src/contribute/github_good_first_issues.rs
+++ b/src/contribute/github_good_first_issues.rs
@@ -282,6 +282,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let result = backend.find_opportunities(&project).unwrap();
@@ -303,6 +304,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let result = backend.find_opportunities(&project).unwrap();

--- a/src/contribute/github_sync.rs
+++ b/src/contribute/github_sync.rs
@@ -438,6 +438,7 @@ mod tests {
                 documentation_url: None,
                 good_first_issues_url: None,
                 stars: None,
+                description: None,
             },
             UpstreamProject {
                 name: "gitlab-project".to_string(),
@@ -451,6 +452,7 @@ mod tests {
                 documentation_url: None,
                 good_first_issues_url: None,
                 stars: None,
+                description: None,
             },
             UpstreamProject {
                 name: "no-repo".to_string(),
@@ -464,6 +466,7 @@ mod tests {
                 documentation_url: None,
                 good_first_issues_url: None,
                 stars: None,
+                description: None,
             },
             UpstreamProject {
                 name: "rust".to_string(),
@@ -477,6 +480,7 @@ mod tests {
                 documentation_url: None,
                 good_first_issues_url: None,
                 stars: None,
+                description: None,
             },
         ];
 

--- a/src/contribute/mod.rs
+++ b/src/contribute/mod.rs
@@ -429,6 +429,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let opportunities = backend.find_opportunities(&project).unwrap();

--- a/src/contribute/suggest.rs
+++ b/src/contribute/suggest.rs
@@ -336,6 +336,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         }
     }
 

--- a/src/enrich/github.rs
+++ b/src/enrich/github.rs
@@ -26,7 +26,6 @@ struct GhRepo {
     #[serde(rename = "hasIssuesEnabled")]
     has_issues_enabled: Option<bool>,
     url: Option<String>,
-    #[allow(dead_code)]
     description: Option<String>,
 }
 
@@ -66,6 +65,9 @@ impl EnrichmentBackend for GitHubBackend {
         if let Ok(repo) = fetch_repo_metadata(&owner_repo) {
             if enriched.stars.is_none() {
                 enriched.stars = repo.stargazer_count;
+            }
+            if enriched.description.is_none() {
+                enriched.description = repo.description.clone();
             }
             if enriched.homepage.is_none()
                 && let Some(hp) = &repo.homepage_url

--- a/src/enrich/license_classify.rs
+++ b/src/enrich/license_classify.rs
@@ -228,6 +228,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let enriched = backend.enrich(&project).unwrap();
@@ -249,6 +250,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let enriched = backend.enrich(&project).unwrap();
@@ -270,6 +272,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let enriched = backend.enrich(&project).unwrap();
@@ -291,6 +294,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         let enriched = backend.enrich(&project).unwrap();

--- a/src/enrich/mod.rs
+++ b/src/enrich/mod.rs
@@ -76,6 +76,9 @@ pub fn active_backends(_config: &Config) -> Vec<Box<dyn EnrichmentBackend + Send
 pub fn merge_enrichment(base: &UpstreamProject, enriched: &UpstreamProject) -> UpstreamProject {
     let mut result = base.clone();
 
+    if result.description.is_none() && enriched.description.is_some() {
+        result.description = enriched.description.clone();
+    }
     if result.homepage.is_none() && enriched.homepage.is_some() {
         result.homepage = enriched.homepage.clone();
     }
@@ -168,6 +171,7 @@ pub fn enrich_packages(
                         documentation_url: None,
                         good_first_issues_url: None,
                         stars: None,
+                        description: None,
                     });
             }
         }
@@ -292,6 +296,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         }
     }
 
@@ -390,6 +395,33 @@ mod tests {
         let result = merge_enrichment(&base, &enriched);
         assert_eq!(result.homepage.as_deref(), Some("https://example.com"));
         assert_eq!(result.stars, Some(42));
+    }
+
+    #[test]
+    fn merge_fills_description() {
+        let base = empty_project("test");
+        let enriched = UpstreamProject {
+            description: Some("A cool project".to_string()),
+            ..empty_project("test")
+        };
+
+        let result = merge_enrichment(&base, &enriched);
+        assert_eq!(result.description.as_deref(), Some("A cool project"));
+    }
+
+    #[test]
+    fn merge_does_not_overwrite_existing_description() {
+        let base = UpstreamProject {
+            description: Some("Original desc".to_string()),
+            ..empty_project("test")
+        };
+        let enriched = UpstreamProject {
+            description: Some("New desc".to_string()),
+            ..empty_project("test")
+        };
+
+        let result = merge_enrichment(&base, &enriched);
+        assert_eq!(result.description.as_deref(), Some("Original desc"));
     }
 
     #[test]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -41,6 +41,10 @@ pub struct UpstreamProject {
     /// Star/favorite count (e.g. GitHub stars)
     #[serde(default)]
     pub stars: Option<u64>,
+
+    /// Short project description (e.g. from GitHub)
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 /// A way to financially support a project.

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -26,6 +26,9 @@ pub struct JsonProject {
     /// Funding channels for this project.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub funding: Vec<FundingChannel>,
+    /// Short project description (e.g. from GitHub).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Star/favorite count (e.g. GitHub stars).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stars: Option<u64>,
@@ -80,6 +83,7 @@ pub fn print_json(
                 project_urls: g.project_urls.clone(),
                 package_names,
                 funding: enriched.map(|e| e.funding.clone()).unwrap_or_default(),
+                description: enriched.and_then(|e| e.description.clone()),
                 stars: enriched.and_then(|e| e.stars),
                 is_open_source: enriched.and_then(|e| e.is_open_source),
                 contributions: project_contributions,
@@ -157,6 +161,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![],
                 },
                 JsonProject {
@@ -166,6 +171,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![],
                 },
             ],
@@ -276,6 +282,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![],
                 },
                 JsonProject {
@@ -285,6 +292,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![],
                 },
             ],
@@ -378,6 +386,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![
                         ContributionOpportunity {
                             kind: ContributionKind::GoodFirstIssue,
@@ -400,6 +409,7 @@ mod tests {
                     funding: vec![],
                     stars: None,
                     is_open_source: None,
+                    description: None,
                     contributions: vec![],
                 },
             ],
@@ -444,6 +454,7 @@ mod tests {
                 project_urls: vec![],
                 package_names: vec!["linux".to_string()],
                 funding: vec![],
+                description: None,
                 stars: None,
                 is_open_source: None,
                 contributions: vec![ContributionOpportunity {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -110,7 +110,8 @@ impl Storage {
                 is_open_source    INTEGER,
                 documentation_url TEXT,
                 good_first_issues_url TEXT,
-                stars             INTEGER
+                stars             INTEGER,
+                description       TEXT
             );
 
             CREATE TABLE IF NOT EXISTS donation_history (
@@ -140,6 +141,13 @@ impl Storage {
             ",
             )
             .context("Failed to run database migrations")?;
+
+        // Add description column to projects table (for databases created before this field existed).
+        // Ignore the error — it fires harmlessly when the column already exists.
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE projects ADD COLUMN description TEXT;");
+
         Ok(())
     }
 
@@ -312,8 +320,8 @@ impl Storage {
             "INSERT OR REPLACE INTO projects
              (url, name, repo_url, homepage, licenses, funding, bug_tracker,
               contributing_url, is_open_source, documentation_url,
-              good_first_issues_url, stars)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+              good_first_issues_url, stars, description)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 url,
                 project.name,
@@ -327,6 +335,7 @@ impl Storage {
                 project.documentation_url,
                 project.good_first_issues_url,
                 project.stars.map(|s| s as i64),
+                project.description,
             ],
         )?;
 
@@ -338,7 +347,7 @@ impl Storage {
         let mut stmt = self.conn.prepare(
             "SELECT name, repo_url, homepage, licenses, funding, bug_tracker,
                     contributing_url, is_open_source, documentation_url,
-                    good_first_issues_url, stars
+                    good_first_issues_url, stars, description
              FROM projects WHERE url = ?1",
         )?;
 
@@ -355,6 +364,7 @@ impl Storage {
                 row.get::<_, Option<String>>(8)?,
                 row.get::<_, Option<String>>(9)?,
                 row.get::<_, Option<i64>>(10)?,
+                row.get::<_, Option<String>>(11)?,
             ))
         });
 
@@ -371,6 +381,7 @@ impl Storage {
                 documentation_url,
                 good_first_issues_url,
                 stars,
+                description,
             )) => {
                 let licenses: Vec<String> = serde_json::from_str(&licenses_json)
                     .context("Failed to deserialize licenses")?;
@@ -388,6 +399,7 @@ impl Storage {
                     documentation_url,
                     good_first_issues_url,
                     stars: stars.map(|s| s as u64),
+                    description,
                 }))
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -400,7 +412,7 @@ impl Storage {
         let mut stmt = self.conn.prepare(
             "SELECT name, repo_url, homepage, licenses, funding, bug_tracker,
                     contributing_url, is_open_source, documentation_url,
-                    good_first_issues_url, stars
+                    good_first_issues_url, stars, description
              FROM projects ORDER BY name",
         )?;
 
@@ -418,6 +430,7 @@ impl Storage {
                     row.get::<_, Option<String>>(8)?,
                     row.get::<_, Option<String>>(9)?,
                     row.get::<_, Option<i64>>(10)?,
+                    row.get::<_, Option<String>>(11)?,
                 ))
             })?
             .map(|r| {
@@ -433,6 +446,7 @@ impl Storage {
                     documentation_url,
                     good_first_issues_url,
                     stars,
+                    description,
                 ) = r?;
                 let licenses: Vec<String> = serde_json::from_str(&licenses_json)
                     .context("Failed to deserialize licenses")?;
@@ -450,6 +464,7 @@ impl Storage {
                     documentation_url,
                     good_first_issues_url,
                     stars: stars.map(|s| s as u64),
+                    description,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -960,6 +975,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         storage
@@ -1006,6 +1022,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
         storage
             .save_enrichment("https://example.org", &project1)
@@ -1023,6 +1040,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
         storage
             .save_enrichment("https://example.org", &project2)
@@ -1103,6 +1121,7 @@ mod tests {
             documentation_url: Some("https://firefox-source-docs.mozilla.org".to_string()),
             good_first_issues_url: Some("https://codetribute.mozilla.org".to_string()),
             stars: Some(1234),
+            description: None,
         }
     }
 
@@ -1157,6 +1176,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         storage.save_project(&project).unwrap();
@@ -1179,6 +1199,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
 
         assert!(storage.save_project(&project).is_err());
@@ -1328,6 +1349,7 @@ mod tests {
             documentation_url: None,
             good_first_issues_url: None,
             stars: None,
+            description: None,
         };
         storage
             .save_enrichment("https://a.example.org", &project)


### PR DESCRIPTION
## Summary

Closes #118.

- Adds a `description: Option<String>` field to `UpstreamProject`, wired through enrichment merge logic, JSON reports, storage layer, and JSON schema
- Removes `#[allow(dead_code)]` from `GhRepo::description` — the field is now actively used to populate upstream project descriptions from GitHub API data
- Adds database migration (`ALTER TABLE`) for existing databases
- Includes two new unit tests for description merge behavior

## Test plan

- [x] `cargo check` passes
- [x] All 334 unit tests + 77 integration tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] JSON schema updated and validated by existing schema tests