### PR TITLE
feat: add Discord notifications to release workflows

### DIFF
--- a/.github/workflows/release-aarch64.yml
+++ b/.github/workflows/release-aarch64.yml
@@ -53,3 +53,23 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: syld-${{ env.TARGET }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_TECH_WEBHOOK }}
+          message: |
+            The release (aarch64) workflow failed.
+            Please check the logs for more details
+            - **Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Notify on Discord
+        if: success()
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_TECH_WEBHOOK }}
+          message: |
+            A new release has been published:
+            - **Tag**: ${{ github.ref_name }}
+            - **Release**: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}

--- a/.github/workflows/release-x86_64.yml
+++ b/.github/workflows/release-x86_64.yml
@@ -63,3 +63,23 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.body }}
           files: syld-${{ env.TARGET }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_TECH_WEBHOOK }}
+          message: |
+            The release (x86_64) workflow failed.
+            Please check the logs for more details
+            - **Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Notify on Discord
+        if: success()
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_TECH_WEBHOOK }}
+          message: |
+            A new release has been published:
+            - **Tag**: ${{ github.ref_name }}
+            - **Release**: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Add Discord notifications to both release workflows (x86_64 and aarch64)
- Notify on failure with a link to the workflow run
- Notify on success with the tag name and release link
- Uses the same `DISCORD_TECH_WEBHOOK` secret as the bump-deps workflow

## Context
The v0.6.1 release was tagged from the wrong commit (before the version bump). That release and tag have been deleted. After merging this PR, v0.6.2 will be released manually.