### PR TITLE
fix: consistent stderr/stdout separation for messages vs data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -511,21 +511,21 @@ fn cmd_contribute_star(project: Option<&str>) -> Result<()> {
             .context("Failed to run gh api")?;
 
         if output.status.success() {
-            println!("\u{2b50} Starred {owner_repo} on GitHub");
-            println!("  {repo_url}");
+            eprintln!("\u{2b50} Starred {owner_repo} on GitHub");
+            eprintln!("  {repo_url}");
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
             if stderr.contains("422") || stderr.contains("already") {
-                println!("\u{2b50} {owner_repo} is already starred");
-                println!("  {repo_url}");
+                eprintln!("\u{2b50} {owner_repo} is already starred");
+                eprintln!("  {repo_url}");
             } else {
                 anyhow::bail!("Failed to star {owner_repo}: {stderr}");
             }
         }
     } else {
         // Fallback: print the URL
-        println!("\u{2b50} Star {owner_repo} on GitHub:");
-        println!("  {repo_url}");
+        eprintln!("\u{2b50} Star {owner_repo} on GitHub:");
+        eprintln!("  {repo_url}");
         eprintln!(
             "\nTip: install and authenticate the `gh` CLI to star directly from the terminal."
         );
@@ -606,16 +606,16 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
                 serde_json::from_str(&stdout).context("Failed to parse gh issue list JSON")?;
 
             if issues.is_empty() {
-                println!("No good first issues found for {owner_repo}");
-                println!("  Browse all issues: https://github.com/{owner_repo}/issues");
+                eprintln!("No good first issues found for {owner_repo}");
+                eprintln!("  Browse all issues: https://github.com/{owner_repo}/issues");
             } else {
-                println!(
+                eprintln!(
                     "Good first issues for {owner_repo} ({} found):\n",
                     issues.len()
                 );
                 for (i, issue) in issues.iter().enumerate() {
-                    println!("  {}. {}", i + 1, issue.title);
-                    println!("     {}", issue.url);
+                    eprintln!("  {}. {}", i + 1, issue.title);
+                    eprintln!("     {}", issue.url);
                 }
             }
         } else {
@@ -624,8 +624,8 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
                 || stderr.contains("not found")
                 || stderr.contains("403")
             {
-                println!("Could not access issues for {owner_repo}");
-                println!(
+                eprintln!("Could not access issues for {owner_repo}");
+                eprintln!(
                     "  Browse issues: https://github.com/{owner_repo}/issues?q=label:%22good+first+issue%22"
                 );
             } else {
@@ -634,8 +634,8 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
         }
     } else {
         // Fallback: print the URL
-        println!("Good first issues for {owner_repo}:");
-        println!("  https://github.com/{owner_repo}/issues?q=label:%22good+first+issue%22");
+        eprintln!("Good first issues for {owner_repo}:");
+        eprintln!("  https://github.com/{owner_repo}/issues?q=label:%22good+first+issue%22");
         eprintln!(
             "\nTip: install and authenticate the `gh` CLI to list issues directly from the terminal."
         );
@@ -727,9 +727,9 @@ fn cmd_contribute_donate(project: Option<&str>) -> Result<()> {
         return Ok(());
     }
 
-    println!("Funding channels:\n");
+    eprintln!("Funding channels:\n");
     for channel in &funding {
-        println!("  {} — {}", channel.platform, channel.url);
+        eprintln!("  {} — {}", channel.platform, channel.url);
     }
 
     // Record the contribution in the database
@@ -773,7 +773,7 @@ fn cmd_contribute_docs(project: Option<&str>) -> Result<()> {
                     // No known contributing URL — verify the file exists before
                     // sending the user to a potentially dead link.
                     if is_gh_available() && !contributing_file_exists(&owner_repo) {
-                        println!(
+                        eprintln!(
                             "{owner_repo} does not have a CONTRIBUTING.md yet — \
                              creating one would be a great first contribution!"
                         );
@@ -813,8 +813,8 @@ fn cmd_contribute_docs(project: Option<&str>) -> Result<()> {
         }
     };
 
-    println!("Contributing guide:");
-    println!("  {contributing_url}");
+    eprintln!("Contributing guide:");
+    eprintln!("  {contributing_url}");
 
     // Record the contribution in the database
     if !storage
@@ -1034,7 +1034,7 @@ fn cmd_hook_list() -> Result<()> {
         } else {
             "not available"
         };
-        println!("  {:<30} {} [{}]", h.name(), h.description(), status);
+        eprintln!("  {:<30} {} [{}]", h.name(), h.description(), status);
     }
 
     Ok(())

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -200,7 +200,7 @@ fn print_project_table(
         render_group_table(page, has_multiple_sources, enrichment);
 
         if remaining > 0 {
-            println!(
+            eprintln!(
                 "\n  ... and {} more projects (use --limit 0 to show all, or --paginate)",
                 remaining
             );
@@ -241,7 +241,7 @@ fn print_project_table(
         }
 
         offset = end;
-        println!();
+        eprintln!();
     }
 }
 
@@ -260,7 +260,7 @@ pub fn print_summary(
     contribution_summary: Option<&ContributionSummary>,
 ) {
     if packages.is_empty() {
-        println!("No packages found.");
+        eprintln!("No packages found.");
         return;
     }
 

--- a/tests/contribute_cli.rs
+++ b/tests/contribute_cli.rs
@@ -169,8 +169,8 @@ fn contribute_docs_with_project_prints_url() {
         .args(["contribute", "docs", "--project", "curl/curl"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Contributing guide:"))
-        .stdout(predicate::str::contains(
+        .stderr(predicate::str::contains("Contributing guide:"))
+        .stderr(predicate::str::contains(
             "https://github.com/curl/curl/blob/HEAD/CONTRIBUTING.md",
         ));
 }

--- a/tests/hook_cli.rs
+++ b/tests/hook_cli.rs
@@ -21,7 +21,7 @@ fn hook_list_succeeds_and_shows_pacman() {
         .args(["hook", "list"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("pacman-post-transaction"));
+        .stderr(predicate::str::contains("pacman-post-transaction"));
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn hook_list_succeeds_and_shows_apt() {
         .args(["hook", "list"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("apt-post-invoke"));
+        .stderr(predicate::str::contains("apt-post-invoke"));
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn hook_list_succeeds_and_shows_dnf() {
         .args(["hook", "list"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("dnf-post-transaction"));
+        .stderr(predicate::str::contains("dnf-post-transaction"));
 }
 
 #[test]
@@ -119,10 +119,10 @@ fn hook_list_shows_availability_status() {
         .unwrap();
 
     assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
     // Should show either "available" or "not available"
     assert!(
-        stdout.contains("available"),
+        stderr.contains("available"),
         "hook list should show availability status"
     );
 }


### PR DESCRIPTION
## Summary

- Route all human-facing messages (star confirmations, issue listings, funding channels, contributing guides, hook listings, pagination prompts, "No packages found") to stderr via `eprintln!()`
- Keep only data output on stdout: report tables/stats (terminal), JSON, HTML, config dump, suggestions
- Update integration tests to match new stderr/stdout assignments

This follows the Unix convention so piping works cleanly:
```bash
syld report --format json | jq .   # no status messages in JSON stream
syld report --format html > report.html  # no progress messages in file
```

Closes #116

## Test plan
- [x] All 376 existing tests pass
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit hooks)