### PR TITLE
refactor: reduce unnecessary .clone() calls in hot paths

### DIFF
--- a/src/discover/brew.rs
+++ b/src/discover/brew.rs
@@ -100,41 +100,35 @@ fn parse_brew_info(json: &str) -> Result<Vec<InstalledPackage>> {
 
     let mut packages = Vec::with_capacity(total);
 
-    for formula in &info.formulae {
+    for formula in info.formulae {
         let version = formula
             .installed
-            .first()
-            .map(|v| v.version.clone())
+            .into_iter()
+            .next()
+            .map(|v| v.version)
             .unwrap_or_else(|| "unknown".to_string());
 
-        let licenses = formula
-            .license
-            .as_ref()
-            .map(|l| vec![l.clone()])
-            .unwrap_or_default();
+        let licenses = formula.license.map(|l| vec![l]).unwrap_or_default();
 
         packages.push(InstalledPackage {
-            name: formula.name.clone(),
+            name: formula.name,
             version,
-            description: formula.desc.clone(),
-            url: formula.homepage.clone(),
+            description: formula.desc,
+            url: formula.homepage,
             source: PackageSource::Brew,
             licenses,
         });
         pb.inc(1);
     }
 
-    for cask in &info.casks {
-        let version = cask
-            .version
-            .clone()
-            .unwrap_or_else(|| "unknown".to_string());
+    for cask in info.casks {
+        let version = cask.version.unwrap_or_else(|| "unknown".to_string());
 
         packages.push(InstalledPackage {
-            name: cask.token.clone(),
+            name: cask.token,
             version,
-            description: cask.desc.clone(),
-            url: cask.homepage.clone(),
+            description: cask.desc,
+            url: cask.homepage,
             source: PackageSource::Brew,
             licenses: Vec::new(),
         });

--- a/src/enrich/mod.rs
+++ b/src/enrich/mod.rs
@@ -67,8 +67,8 @@ pub fn active_backends(_config: &Config) -> Vec<Box<dyn EnrichmentBackend + Send
 ///
 /// Non-empty fields from `enriched` overlay `base`. Funding channels are
 /// deduplicated by URL.
-pub fn merge_enrichment(base: &UpstreamProject, enriched: &UpstreamProject) -> UpstreamProject {
-    let mut result = base.clone();
+pub fn merge_enrichment(base: UpstreamProject, enriched: &UpstreamProject) -> UpstreamProject {
+    let mut result = base;
 
     if result.description.is_none() && enriched.description.is_some() {
         result.description = enriched.description.clone();
@@ -218,7 +218,7 @@ pub fn enrich_packages(
                 for backend in &backends {
                     match backend.enrich(&enriched) {
                         Ok(result) => {
-                            enriched = merge_enrichment(&enriched, &result);
+                            enriched = merge_enrichment(enriched, &result);
                         }
                         Err(e) => {
                             eprintln!(
@@ -305,7 +305,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.homepage.as_deref(), Some("https://example.com"));
         assert_eq!(result.stars, Some(42));
         assert_eq!(
@@ -328,7 +328,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.homepage.as_deref(), Some("https://original.com"));
         assert_eq!(result.stars, Some(100));
     }
@@ -356,7 +356,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.funding.len(), 2);
         assert_eq!(result.funding[0].platform, "GitHub Sponsors");
         assert_eq!(result.funding[1].platform, "Open Collective");
@@ -373,7 +373,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.licenses, vec!["MIT", "Apache-2.0"]);
     }
 
@@ -386,7 +386,7 @@ mod tests {
         };
         let enriched = empty_project("test");
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.homepage.as_deref(), Some("https://example.com"));
         assert_eq!(result.stars, Some(42));
     }
@@ -399,7 +399,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.description.as_deref(), Some("A cool project"));
     }
 
@@ -414,7 +414,7 @@ mod tests {
             ..empty_project("test")
         };
 
-        let result = merge_enrichment(&base, &enriched);
+        let result = merge_enrichment(base, &enriched);
         assert_eq!(result.description.as_deref(), Some("Original desc"));
     }
 


### PR DESCRIPTION
## Summary

- **brew.rs**: Consume deserialized `BrewInfoOutput` with `into_iter()` instead of borrowing and cloning every field (name, desc, homepage, version, license) when building `InstalledPackage` entries
- **enrich/mod.rs**: Take `base` `UpstreamProject` by value in `merge_enrichment()` to avoid cloning the entire struct on entry; update all call sites accordingly

Cold paths (suggest.rs generators, main.rs CLI commands) left as-is per issue guidance — clarity > micro-optimization for one-shot operations.

Closes #122

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes
- [x] All 334 unit tests pass
- [x] No behavioral changes — pure refactor