### PR TITLE
Standardize error handling pattern across modules

### DIFF
--- a/src/contribute/github_sync.rs
+++ b/src/contribute/github_sync.rs
@@ -135,7 +135,7 @@ fn fetch_user_issues(owner_repo: &str) -> Result<Vec<SearchItem>> {
             || stderr.contains("401")
             || stderr.contains("422")
         {
-            eprintln!("    warning: skipping issues for {owner_repo}: {stderr}");
+            eprintln!("warning: skipping issues for {owner_repo}: {stderr}");
             return Ok(Vec::new());
         }
         anyhow::bail!("gh api search/issues failed for {owner_repo}: {stderr}");
@@ -162,7 +162,7 @@ fn fetch_user_pull_requests(owner_repo: &str) -> Result<Vec<SearchItem>> {
             || stderr.contains("401")
             || stderr.contains("422")
         {
-            eprintln!("    warning: skipping PRs for {owner_repo}: {stderr}");
+            eprintln!("warning: skipping PRs for {owner_repo}: {stderr}");
             return Ok(Vec::new());
         }
         anyhow::bail!("gh api search/issues (PRs) failed for {owner_repo}: {stderr}");
@@ -232,10 +232,19 @@ pub fn sync_github_contributions(
             for gp in &github_projects {
                 let key = gp.owner_repo.to_lowercase();
                 if starred.contains(&key) {
-                    if storage
+                    let already_recorded = match storage
                         .has_contribution(&gp.repo_url, &ContributionRecordKind::Star)
-                        .unwrap_or(false)
                     {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!(
+                                "warning: failed to check star contribution for {}: {e}",
+                                gp.project.name
+                            );
+                            false
+                        }
+                    };
+                    if already_recorded {
                         continue;
                     }
                     if let Err(e) = storage.save_contribution(
@@ -246,10 +255,7 @@ pub fn sync_github_contributions(
                         Utc::now(),
                         Some("github_sync"),
                     ) {
-                        eprintln!(
-                            "    warning: failed to save star for {}: {e}",
-                            gp.project.name
-                        );
+                        eprintln!("warning: failed to save star for {}: {e}", gp.project.name);
                         continue;
                     }
                     result.stars += 1;
@@ -257,7 +263,7 @@ pub fn sync_github_contributions(
             }
         }
         Err(e) => {
-            eprintln!("  warning: failed to fetch starred repos: {e}");
+            eprintln!("warning: failed to fetch starred repos: {e}");
         }
     }
 
@@ -268,10 +274,17 @@ pub fn sync_github_contributions(
             Ok(issues) => {
                 for item in &issues {
                     // Dedup by URL since a project can have multiple issues
-                    if storage
-                        .has_contribution_url(&item.html_url)
-                        .unwrap_or(false)
-                    {
+                    let already_recorded = match storage.has_contribution_url(&item.html_url) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!(
+                                "warning: failed to check contribution URL {}: {e}",
+                                item.html_url
+                            );
+                            false
+                        }
+                    };
+                    if already_recorded {
                         continue;
                     }
                     let dt = parse_datetime(&item.created_at);
@@ -283,20 +296,14 @@ pub fn sync_github_contributions(
                         dt,
                         Some("github_sync"),
                     ) {
-                        eprintln!(
-                            "    warning: failed to save issue for {}: {e}",
-                            gp.project.name
-                        );
+                        eprintln!("warning: failed to save issue for {}: {e}", gp.project.name);
                     } else {
                         result.issues += 1;
                     }
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "    warning: failed to fetch issues for {}: {e}",
-                    gp.owner_repo
-                );
+                eprintln!("warning: failed to fetch issues for {}: {e}", gp.owner_repo);
             }
         }
 
@@ -305,10 +312,17 @@ pub fn sync_github_contributions(
             Ok(prs) => {
                 for item in &prs {
                     // Dedup by URL since a project can have multiple PRs
-                    if storage
-                        .has_contribution_url(&item.html_url)
-                        .unwrap_or(false)
-                    {
+                    let already_recorded = match storage.has_contribution_url(&item.html_url) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!(
+                                "warning: failed to check contribution URL {}: {e}",
+                                item.html_url
+                            );
+                            false
+                        }
+                    };
+                    if already_recorded {
                         continue;
                     }
                     let dt = parse_datetime(&item.created_at);
@@ -320,20 +334,14 @@ pub fn sync_github_contributions(
                         dt,
                         Some("github_sync"),
                     ) {
-                        eprintln!(
-                            "    warning: failed to save PR for {}: {e}",
-                            gp.project.name
-                        );
+                        eprintln!("warning: failed to save PR for {}: {e}", gp.project.name);
                     } else {
                         result.pull_requests += 1;
                     }
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "    warning: failed to fetch PRs for {}: {e}",
-                    gp.owner_repo
-                );
+                eprintln!("warning: failed to fetch PRs for {}: {e}", gp.owner_repo);
             }
         }
     }

--- a/src/discover/docker.rs
+++ b/src/discover/docker.rs
@@ -126,15 +126,26 @@ fn fetch_image_labels(image_id: &str) -> HashMap<String, String> {
 
     let output = match output {
         Ok(o) if o.status.success() => o,
-        _ => return HashMap::new(),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            eprintln!("warning: failed to inspect docker image {image_id}: {stderr}");
+            return HashMap::new();
+        }
+        Err(e) => {
+            eprintln!("warning: failed to inspect docker image {image_id}: {e}");
+            return HashMap::new();
+        }
     };
 
-    let stdout = match String::from_utf8(output.stdout) {
-        Ok(s) => s,
-        Err(_) => return HashMap::new(),
-    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
-    oci::parse_labels(&stdout).unwrap_or_default()
+    match oci::parse_labels(&stdout) {
+        Ok(labels) => labels,
+        Err(e) => {
+            eprintln!("warning: failed to parse labels for docker image {image_id}: {e}");
+            HashMap::new()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/discover/podman.rs
+++ b/src/discover/podman.rs
@@ -140,15 +140,26 @@ fn fetch_image_labels(image_id: &str) -> HashMap<String, String> {
 
     let output = match output {
         Ok(o) if o.status.success() => o,
-        _ => return HashMap::new(),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            eprintln!("warning: failed to inspect podman image {image_id}: {stderr}");
+            return HashMap::new();
+        }
+        Err(e) => {
+            eprintln!("warning: failed to inspect podman image {image_id}: {e}");
+            return HashMap::new();
+        }
     };
 
-    let stdout = match String::from_utf8(output.stdout) {
-        Ok(s) => s,
-        Err(_) => return HashMap::new(),
-    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
-    oci::parse_labels(&stdout).unwrap_or_default()
+    match oci::parse_labels(&stdout) {
+        Ok(labels) => labels,
+        Err(e) => {
+            eprintln!("warning: failed to parse labels for podman image {image_id}: {e}");
+            HashMap::new()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/enrich/github.rs
+++ b/src/enrich/github.rs
@@ -190,10 +190,14 @@ fn fetch_funding_yml(owner_repo: &str) -> Result<Vec<FundingChannel>> {
         .context("Failed to run gh api for FUNDING.yml")?;
 
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("Not Found") && !stderr.contains("404") {
+            eprintln!("warning: failed to fetch FUNDING.yml for {owner_repo}: {stderr}");
+        }
         return Ok(Vec::new());
     }
 
-    let stdout = String::from_utf8(output.stdout).unwrap_or_default();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let content = decode_base64_content(&stdout);
 
     Ok(parse_funding_yml(&content))
@@ -205,7 +209,13 @@ fn decode_base64_content(encoded: &str) -> String {
     let clean: String = encoded.chars().filter(|c| !c.is_whitespace()).collect();
 
     // Simple base64 decode without pulling in a dependency
-    base64_decode(&clean).unwrap_or_default()
+    match base64_decode(&clean) {
+        Some(s) => s,
+        None => {
+            eprintln!("warning: failed to decode base64 content from GitHub API");
+            String::new()
+        }
+    }
 }
 
 fn base64_decode(input: &str) -> Option<String> {

--- a/src/hook/apt_post_invoke.rs
+++ b/src/hook/apt_post_invoke.rs
@@ -49,7 +49,15 @@ impl Hook for AptPostInvokeHook {
         let storage = match ctx.db_path {
             Some(ref path) => match Storage::open_path(path) {
                 Ok(s) => s,
-                Err(_) => return Ok(()),
+                Err(e) => {
+                    if path.exists() {
+                        eprintln!(
+                            "warning: failed to open database at {}: {e}",
+                            path.display()
+                        );
+                    }
+                    return Ok(());
+                }
             },
             None => match Storage::open() {
                 Ok(s) => s,
@@ -58,14 +66,26 @@ impl Hook for AptPostInvokeHook {
         };
 
         // Load all enriched projects from the database.
-        let projects = storage.all_projects().unwrap_or_default();
+        let projects = match storage.all_projects() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("warning: failed to load projects: {e}");
+                return Ok(());
+            }
+        };
         if projects.is_empty() {
             return Ok(());
         }
 
         // Generate suggestions using the contribute engine, excluding
         // contributions the user has already completed.
-        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let contributions = match storage.get_contributions(None, None) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("warning: failed to load contributions: {e}");
+                Vec::new()
+            }
+        };
         let suggestions =
             suggest::generate_suggestions(&projects, &contributions, SuggestionKind::ALL);
 

--- a/src/hook/dnf_post_transaction.rs
+++ b/src/hook/dnf_post_transaction.rs
@@ -49,7 +49,15 @@ impl Hook for DnfPostTransactionHook {
         let storage = match ctx.db_path {
             Some(ref path) => match Storage::open_path(path) {
                 Ok(s) => s,
-                Err(_) => return Ok(()),
+                Err(e) => {
+                    if path.exists() {
+                        eprintln!(
+                            "warning: failed to open database at {}: {e}",
+                            path.display()
+                        );
+                    }
+                    return Ok(());
+                }
             },
             None => match Storage::open() {
                 Ok(s) => s,
@@ -58,14 +66,26 @@ impl Hook for DnfPostTransactionHook {
         };
 
         // Load all enriched projects from the database.
-        let projects = storage.all_projects().unwrap_or_default();
+        let projects = match storage.all_projects() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("warning: failed to load projects: {e}");
+                return Ok(());
+            }
+        };
         if projects.is_empty() {
             return Ok(());
         }
 
         // Generate suggestions using the contribute engine, excluding
         // contributions the user has already completed.
-        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let contributions = match storage.get_contributions(None, None) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("warning: failed to load contributions: {e}");
+                Vec::new()
+            }
+        };
         let suggestions =
             suggest::generate_suggestions(&projects, &contributions, SuggestionKind::ALL);
 

--- a/src/hook/pacman_post_transaction.rs
+++ b/src/hook/pacman_post_transaction.rs
@@ -49,7 +49,15 @@ impl Hook for PacmanPostTransactionHook {
         let storage = match ctx.db_path {
             Some(ref path) => match Storage::open_path(path) {
                 Ok(s) => s,
-                Err(_) => return Ok(()),
+                Err(e) => {
+                    if path.exists() {
+                        eprintln!(
+                            "warning: failed to open database at {}: {e}",
+                            path.display()
+                        );
+                    }
+                    return Ok(());
+                }
             },
             None => match Storage::open() {
                 Ok(s) => s,
@@ -58,14 +66,26 @@ impl Hook for PacmanPostTransactionHook {
         };
 
         // Load all enriched projects from the database.
-        let projects = storage.all_projects().unwrap_or_default();
+        let projects = match storage.all_projects() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("warning: failed to load projects: {e}");
+                return Ok(());
+            }
+        };
         if projects.is_empty() {
             return Ok(());
         }
 
         // Generate suggestions using the contribute engine, excluding
         // contributions the user has already completed.
-        let contributions = storage.get_contributions(None, None).unwrap_or_default();
+        let contributions = match storage.get_contributions(None, None) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("warning: failed to load contributions: {e}");
+                Vec::new()
+            }
+        };
         let suggestions =
             suggest::generate_suggestions(&projects, &contributions, SuggestionKind::ALL);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,11 +330,13 @@ fn cmd_report(config: &Config, format: &ReportFormat, limit: usize, paginate: bo
     let contributions = ContributionMap::new();
 
     // Build contribution summary from stored records
-    let contribution_summary = storage
-        .get_contributions(None, None)
-        .ok()
-        .map(|records| ContributionSummary::from_records(&records))
-        .filter(|s| !s.is_empty());
+    let contribution_summary = {
+        let records = storage
+            .get_contributions(None, None)
+            .context("Failed to load contributions")?;
+        let s = ContributionSummary::from_records(&records);
+        if s.is_empty() { None } else { Some(s) }
+    };
 
     match format {
         ReportFormat::Terminal => {
@@ -418,7 +420,9 @@ fn cmd_contribute(config: &Config, limit: usize, types: Option<&str>) -> Result<
     }
 
     // Load existing contributions to filter already-completed actions.
-    let contributions = storage.get_contributions(None, None).unwrap_or_default();
+    let contributions = storage
+        .get_contributions(None, None)
+        .context("Failed to load contributions")?;
 
     // Generate suggestions from enrichment data.
     let suggestions = suggest::generate_suggestions(&projects, &contributions, &filter);
@@ -476,7 +480,9 @@ fn cmd_contribute_star(project: Option<&str>) -> Result<()> {
             // Pick a random unstarred project from the database
             let storage = Storage::open().context("Failed to open database")?;
             let projects = storage.all_projects().context("Failed to load projects")?;
-            let contributions = storage.get_contributions(None, None).unwrap_or_default();
+            let contributions = storage
+                .get_contributions(None, None)
+                .context("Failed to load contributions")?;
 
             let suggestions =
                 suggest::generate_suggestions(&projects, &contributions, &[SuggestionKind::Star]);
@@ -535,7 +541,7 @@ fn cmd_contribute_star(project: Option<&str>) -> Result<()> {
     let storage = Storage::open().context("Failed to open database")?;
     if !storage
         .has_contribution(&repo_url, &ContributionRecordKind::Star)
-        .unwrap_or(false)
+        .context("Failed to check contribution status")?
     {
         storage.save_contribution(
             &repo_url,
@@ -557,7 +563,9 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
             // Pick a random project with good first issues from the database
             let storage = Storage::open().context("Failed to open database")?;
             let projects = storage.all_projects().context("Failed to load projects")?;
-            let contributions = storage.get_contributions(None, None).unwrap_or_default();
+            let contributions = storage
+                .get_contributions(None, None)
+                .context("Failed to load contributions")?;
 
             let suggestions =
                 suggest::generate_suggestions(&projects, &contributions, &[SuggestionKind::Issue]);
@@ -645,7 +653,7 @@ fn cmd_contribute_issue(project: Option<&str>) -> Result<()> {
     let storage = Storage::open().context("Failed to open database")?;
     if !storage
         .has_contribution(&repo_url, &ContributionRecordKind::Issue)
-        .unwrap_or(false)
+        .context("Failed to check contribution status")?
     {
         storage.save_contribution(
             &repo_url,
@@ -687,7 +695,9 @@ fn cmd_contribute_donate(project: Option<&str>) -> Result<()> {
         None => {
             // Pick a random project with funding channels from the database
             let projects = storage.all_projects().context("Failed to load projects")?;
-            let contributions = storage.get_contributions(None, None).unwrap_or_default();
+            let contributions = storage
+                .get_contributions(None, None)
+                .context("Failed to load contributions")?;
 
             let suggestions =
                 suggest::generate_suggestions(&projects, &contributions, &[SuggestionKind::Donate]);
@@ -735,7 +745,7 @@ fn cmd_contribute_donate(project: Option<&str>) -> Result<()> {
     // Record the contribution in the database
     if !storage
         .has_contribution(&project_url, &ContributionRecordKind::Donation)
-        .unwrap_or(false)
+        .context("Failed to check contribution status")?
     {
         storage.save_contribution(
             &project_url,
@@ -788,7 +798,9 @@ fn cmd_contribute_docs(project: Option<&str>) -> Result<()> {
         None => {
             // Pick a random project with a contributing guide from the database
             let projects = storage.all_projects().context("Failed to load projects")?;
-            let contributions = storage.get_contributions(None, None).unwrap_or_default();
+            let contributions = storage
+                .get_contributions(None, None)
+                .context("Failed to load contributions")?;
 
             let suggestions =
                 suggest::generate_suggestions(&projects, &contributions, &[SuggestionKind::Docs]);
@@ -819,7 +831,7 @@ fn cmd_contribute_docs(project: Option<&str>) -> Result<()> {
     // Record the contribution in the database
     if !storage
         .has_contribution(&project_url, &ContributionRecordKind::Docs)
-        .unwrap_or(false)
+        .context("Failed to check contribution status")?
     {
         storage.save_contribution(
             &project_url,


### PR DESCRIPTION
## Summary

- **main.rs**: Replace `unwrap_or_default()` and `unwrap_or(false)` on storage calls with `.context()?` to propagate database errors to CLI users
- **hook modules** (pacman, apt, dnf): Distinguish "no database yet" from real DB errors — log warnings for unexpected failures while keeping non-fatal behavior
- **github_sync.rs**: Standardize `eprintln!` warning prefixes (remove inconsistent indentation), replace silent `unwrap_or(false)` on DB checks with match blocks that log warnings
- **enrich/github.rs**: Distinguish 404 from API errors in `fetch_funding_yml`, use `from_utf8_lossy` for UTF-8, log warning on base64 decode failure
- **discover modules** (docker, podman): Log warnings for inspect command failures and label parse errors, use `from_utf8_lossy`

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 334 unit tests + 15 main tests + all integration tests pass
- [x] `cargo fmt` and `cargo clippy` clean

Closes #114, #159, #160, #161, #162, #163